### PR TITLE
Use Elixir List.flatten/1 instead of Erlang :lists

### DIFF
--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -192,7 +192,7 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
     Enum.map(parameters,
       fn({:param, params_list}) ->
         Enum.into(params_list, %{})
-      end) |> :lists.flatten
+      end) |> List.flatten
   end
 
   @doc false

--- a/lib/phoenix_swagger.ex
+++ b/lib/phoenix_swagger.ex
@@ -65,7 +65,7 @@ defmodule PhoenixSwagger do
           _ ->
             []
         end
-      end) |> :lists.flatten
+      end) |> List.flatten
   end
 
   @doc false


### PR DESCRIPTION
Why?

Because Elixir provides [List.flatten/1](https://github.com/elixir-lang/elixir/blob/64ee036509c34e097017e89fc0af3818110043d3/lib/elixir/lib/list.ex#L152) which calls to `:lists.flatten` btw.