### PR TITLE
s/swagger.js/swagger.json

### DIFF
--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
   @default_version "0.0.1"
 
   @app_path Enum.at(Mix.Project.load_paths, 0) |> String.split("_build") |> Enum.at(0)
-  @swagger_file_name "swagger.js"
+  @swagger_file_name "swagger.json"
   @swagger_file_path @app_path <> @swagger_file_name
 
   @doc false


### PR DESCRIPTION
The README and the function doc clearly states that default filename is `swagger.json` not `swagger.js`