### PR TITLE
allow both 2.x and 1.5 version of poison

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule PhoenixSwagger.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-        {:poison, "~> 1.5.0"},
+        {:poison, "~> 1.5 or ~> 2.0"},
         {:ex_json_schema, "~> 0.5.1"},
         {:plug, "~> 1.1"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"ex_json_schema": {:hex, :ex_json_schema, "0.5.1", "83356e5a673d6fbe75da612a44b8f84942711630414d8be5e342f3597b03939a", [:mix], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "1.5.2", "560bdfb7449e3ddd23a096929fb9fc2122f709bcc758b2d5d5a5c7d0ea848910", [:mix], []}}
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}


### PR DESCRIPTION
Hi, There!
This patch allows to use both 2.x and 1.5 (or higher) version of poison, which is same as the dependency of [phoenix ver 1.2.1](https://github.com/phoenixframework/phoenix/blob/aa997350f917a6437a059f265a5647cd22625219/mix.exs#L45)
Please let me know if you have any concerns.