### PR TITLE
Use swagger_info title and version defined in mix.exs

### DIFF
--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -132,22 +132,15 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
     case function_exported?(Mix.Project.get, :swagger_info, 0) do
       true ->
         info = Mix.Project.get.swagger_info
-        title = Keyword.get(info, :title, nil)
-        version = Keyword.get(info, :version, nil)
+        title = Keyword.get(info, :title, @default_title)
+        version = Keyword.get(info, :version, @default_version)
         # collect :info swagger fields to the map
         info = List.foldl(info, %{},
           fn ({info_key, info_val}, map) ->
             Map.put_new(map, info_key, info_val)
           end)
-        # :title and :version are mandatory fields,
-        # so we need to check and add default values
-        # if they are not exists
-        info = if title == nil do
-          Map.put_new(info, :title, @default_title)
-        end
-        info = if version == nil do
-          Map.put_new(info, :version, @default_version)
-        end
+          |> Map.put_new(:title, title)
+          |> Map.put_new(:version, version)
         # resulted :info swagger field
         Map.put_new(swagger_map, :info, info)
       false ->


### PR DESCRIPTION
If you defined a `title` in swagger_info, the resulting swagger.json file contained `"info":null`.

On line 145 when the `title` was not nil, `info` would be assigned to null. 
The same thing occurred for `version` on line 148.