### PR TITLE
add support for body parameters with a custom schema

### DIFF
--- a/lib/phoenix_swagger.ex
+++ b/lib/phoenix_swagger.ex
@@ -73,6 +73,14 @@ defmodule PhoenixSwagger do
     Enum.map(parameters,
       fn(metadata) ->
         case metadata do
+          {:parameter, [:body, name, schema, :required, description]} ->
+            {:param, [in: :body, name: name, schema: schema, required: true, description: description]}
+          {:parameter, [:body, name, schema, :required]} ->
+            {:param, [in: :body, name: name, schema: schema, required: true, description: ""]}
+          {:parameter, [:body, name, schema, description]} ->
+            {:param, [in: :body, name: name, schema: schema, required: false, description: description]}
+          {:parameter, [:body, name, schema]} ->
+            {:param, [in: :body, name: name, schema: schema, required: false, description: ""]}
           {:parameter, [path, name, type, :required, description]} ->
             {:param, [in: path, name: name, type: valid_type?(type), required: true, description: description]}
           {:parameter, [path, name, type, :required]} ->


### PR DESCRIPTION
In Swagger, a parameter located in the `body` shouldn't have a `type` - instead, it should have a `schema` describing the data structure in that parameter. This PR adds that functionality so something like this works as intended:

```elixir
swagger_model :create do
  # some stuff
  parameter :body, :user, user_schema, :required, "User"
end

def user_schema do
  %{
    type: :object,
    properties: %{
      name: %{type: :string}
    }
  }
end
```