### PR TITLE
allow additional pipes

### DIFF
--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -177,7 +177,7 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
   defp get_api_routes(router_mod) do
     Enum.filter(router_mod.__routes__,
       fn(route_path) ->
-        route_path.pipe_through == [:api]
+        Enum.member?(route_path.pipe_through, :api)
       end)
   end
 


### PR DESCRIPTION
The `phoenix.swagger.generate` task only picks up routes if they are in a scope that has exactly one pipeline which is equal to `:api`. This is an issue if you have multiple api scopes (ex authenticated vs unauthenticated).