### PR TITLE
validator: add support for multiple schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ Before usage of swagger validator, add the `PhoenixSwagger.Validator.Supervisor`
 your application.
 
 The `phoenix_swagger` provides `PhoenixSwagger.Validator.parse_swagger_schema/1` API to load a swagger schema by
-the given path. This API should be called during application startup to parse/load a swagger schema. After this, the
-`PhoenixSwagger.Validator.validate/2` can be used to validate resources.
+the given path or list of paths. This API should be called during application startup to parse/load a swagger schema.
+
+After this, the `PhoenixSwagger.Validator.validate/2` can be used to validate resources.
 
 For example:
 

--- a/lib/phoenix_swagger/validator.ex
+++ b/lib/phoenix_swagger/validator.ex
@@ -26,8 +26,8 @@ defmodule PhoenixSwagger.Validator do
   @table :validator_table
 
   @doc """
-  The `parse_swagger_schema/1` takes path to a swagger schema, parses it
-  into ex_json_schema format and store to the `validator_table` ets
+  The `parse_swagger_schema/1` takes path or list of paths to a swagger schema(s), 
+  parses it/them into ex_json_schema format and store to the `validator_table` ets
   table.
 
   Usage:
@@ -46,21 +46,57 @@ defmodule PhoenixSwagger.Validator do
       }]
 
   """
-  def parse_swagger_schema(spec) do
-    schema = File.read(spec) |> elem(1) |> Poison.decode() |> elem(1)
-    # get rid from all keys besides 'paths' and 'definitions' as we
-    # need only in these fields for validation
-    schema = Enum.reduce(schema, %{}, fn(map, acc) ->
-      {key, val} = map
-      if key in ["paths", "definitions"] do
-        Map.put_new(acc, key, val)
-      else
-        acc
-      end      
+  def parse_swagger_schema(specs) when is_list(specs) do
+    schemas = Enum.map(specs, fn (spec) ->
+      read_swagger_schema(spec)
     end)
+    schema = Enum.reduce(schemas, %{}, fn(schema, acc) ->
+      acc = if acc["paths"] == nil do
+              Map.merge(acc, schema)
+            else
+              acc = Map.update!(acc, "paths", fn(paths_map) -> Map.merge(paths_map, schema["paths"]) end)
+              Map.update!(acc, "definitions", fn(definitions_map) -> Map.merge(definitions_map, schema["definitions"]) end)
+            end
+      acc
+    end)
+    collect_schema_attrs(schema)
+  end
+  def parse_swagger_schema(spec) do
+    schema = read_swagger_schema(spec)
+    collect_schema_attrs(schema)
+  end
 
-    # parse swagger schema
-    schema = Enum.map(schema["paths"], fn({path, data}) ->
+  @doc """
+  The `validate/2` takes a resource path and input parameters
+  of this resource.
+
+  Returns `:ok` in a case when parameters are valid for the
+  given resource or:
+
+    * {:error, :resource_not_exists} in a case when path is not
+      exists in the validator table;
+    * {:error, error_message, path} in a case when at least
+      one  parameter is not valid for the given resource.
+  """
+  def validate(path, params) do
+    case :ets.lookup(@table, path) do
+      [] ->
+        {:error, :resource_not_exists}
+      [{_, schema}] ->
+        case ExJsonSchema.Validator.validate(schema, params) do
+          :ok ->
+            :ok
+          {:error, [{error, path}]} ->
+            {:error, error, path}
+          {:error, error} ->
+            {:error, error, path}
+        end
+    end
+  end
+
+  @doc false
+  defp collect_schema_attrs(schema) do
+    Enum.map(schema["paths"], fn({path, data}) ->
       Enum.map(Map.keys(data), fn(method) ->
         parameters = data[method]["parameters"]
         # we may have a request without parameters, so nothing to validate
@@ -110,35 +146,6 @@ defmodule PhoenixSwagger.Validator do
         end
       end)
     end) |> List.flatten
-    schema
-  end
-
-  @doc """
-  The `validate/2` takes a resource path and input parameters
-  of this resource.
-
-  Returns `:ok` in a case when parameters are valid for the
-  given resource or:
-
-    * {:error, :resource_not_exists} in a case when path is not
-      exists in the validator table;
-    * {:error, error_message, path} in a case when at least
-      one  parameter is not valid for the given resource.
-  """
-  def validate(path, params) do
-    case :ets.lookup(@table, path) do
-      [] ->
-        {:error, :resource_not_exists}
-      [{_, schema}] ->
-        case ExJsonSchema.Validator.validate(schema, params) do
-          :ok ->
-            :ok
-          {:error, [{error, path}]} ->
-            {:error, error, path}
-          {:error, error} ->
-            {:error, error, path}
-        end
-    end
   end
 
   @doc false
@@ -197,6 +204,21 @@ defmodule PhoenixSwagger.Validator do
           ref_acc = Map.delete(ref_acc, parameter["name"])
           |> Map.put_new(parameter["name"], map)
         end
+      end
+    end)
+  end
+
+  @doc false
+  defp read_swagger_schema(file) do
+    schema = File.read(file) |> elem(1) |> Poison.decode() |> elem(1)
+    # get rid from all keys besides 'paths' and 'definitions' as we
+    # need only in these fields for validation
+    Enum.reduce(schema, %{}, fn(map, acc) ->
+      {key, val} = map
+      if key in ["paths", "definitions"] do
+        Map.put_new(acc, key, val)
+      else
+        acc
       end
     end)
   end

--- a/test/test_spec/swagger_test_spec_2.json
+++ b/test/test_spec/swagger_test_spec_2.json
@@ -1,0 +1,229 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore (Simple)",
+        "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "Swagger API team",
+            "email": "foo@example.com",
+            "url": "http://swagger.io"
+        },
+        "license": {
+            "name": "MIT",
+            "url": "http://opensource.org/licenses/MIT"
+        }
+    },
+    "host": "petstore.swagger.io",
+    "basePath": "/api",
+    "schemes": [
+        "http"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/pets": {
+            "get": {
+                "description": "Returns all pets from the system that the user has access to",
+                "operationId": "findPets",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/xml",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "tags to filter by",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "maximum number of results to return",
+                        "required": false,
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/pet"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new pet in the store.  Duplicates are allowed",
+                "operationId": "addPet",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "body",
+                        "description": "Pet to add to the store",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/newPet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "$ref": "#/definitions/pet"
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            }
+        },
+        "/pets/{id}": {
+            "get": {
+                "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+                "operationId": "findPetById",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/xml",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of pet to fetch",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "$ref": "#/definitions/pet"
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "deletes a single pet based on the ID supplied",
+                "operationId": "deletePet",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of pet to delete",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "pet deleted"
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "pet": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "newPet": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "errorModel": {
+            "type": "object",
+            "required": [
+                "code",
+                "message"
+            ],
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch provides additional clause for `parse_swagger_schema/1`
function to read set of swagger schemas. After reading of list of
swagger schemas, validator merges them into one.

So other behaviour of validator is the same as before.