### PR TITLE
BUGFIX: read port/url from config (also from env if necessary)

### DIFF
--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -116,10 +116,16 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
   @doc false
   defp collect_host(swagger_map, app_name, app_mod) do
     endpoint_config = Application.get_env(app_name,Module.concat([app_mod, :Endpoint]))
-    [{:host, host}] = Keyword.get(endpoint_config, :url, [{:host, "localhost"}])
-    [{:port, port}] = Keyword.get(endpoint_config, :http, [{:port, @default_port}])
+    host =
+      endpoint_config
+      |> Keyword.get(:url, [{:host, "localhost"}])
+      |> Keyword.get(:host, "localhost")
+    port =
+      endpoint_config
+      |> Keyword.get(:http, [{:port, @default_port}])
+      |> Keyword.get(:port, @default_port)
     https = Keyword.get(endpoint_config, :https, nil)
-    swagger_map = Map.put_new(swagger_map, :host, host <> ":" <> to_string(port))
+    swagger_map = Map.put_new(swagger_map, :host, host <> ":" <> port_to_string(port))
     case https do
       nil ->
         swagger_map
@@ -127,6 +133,11 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
         Map.put_new(swagger_map, :schemes, ["https", "http"])
     end
   end
+
+  @doc false
+  defp port_to_string({:system, env_var}), do: port_to_string(System.get_env(env_var))
+  defp port_to_string(port) when is_integer(port), do: to_string(port)
+  defp port_to_string(port) when is_binary(port), do: port
 
   @doc false
   defp collect_info(swagger_map) do


### PR DESCRIPTION
If the config is in prod environment for example and it looks like this:

    (...)
    http: [port: {:system, "PORT"}],
    url: [host: System.get_env("URI"), port: 80],
    (...)

this will generate errors like this:

    ** (MatchError) no match of right hand side value: [host: "localhost", port: "4123"]
     lib/mix/tasks/swagger.generate.ex:119: Mix.Tasks.Phoenix.Swagger.Generate.collect_host/3
     lib/mix/tasks/swagger.generate.ex:56: Mix.Tasks.Phoenix.Swagger.Generate.run/1
     (mix) lib/mix/task.ex:296: Mix.Task.run_task/3
     (mix) lib/mix/task.ex:328: Mix.Task.run_alias/3
     (mix) lib/mix/task.ex:261: Mix.Task.run/2
     (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2

This is a fix for this issue.