### PR TITLE
Fix: create directory if it doesn’t exist for generated file

### DIFF
--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -56,6 +56,10 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
              |> collect_host(app_name, app_mod)
              |> collect_paths(router_mod, app_mod)
              |> Poison.encode!
+    directory = Path.dirname(output_file)
+    unless File.exists? directory do
+      File.mkdir_p! directory
+    end
     File.write(output_file, result)
     Code.delete_path(ebin)
     IO.puts "Done."


### PR DESCRIPTION
If you input some directory which doesn't exist on swaggerfile generation, then it won't be created (and it doesn't throw, which is bad in my opinion too in this case - for instance in CI/CD envs)