### PR TITLE
swagger validator reworked

### DIFF
--- a/test/test_spec/swagger_test_spec_2.json
+++ b/test/test_spec/swagger_test_spec_2.json
@@ -194,13 +194,24 @@
         "newPet": {
             "type": "object",
             "required": [
-                "name"
+                "id", "pet"
             ],
             "properties": {
                 "id": {
                     "type": "integer",
                     "format": "int64"
                 },
+                "pet": {
+                    "$ref": "#/definitions/Pet"
+                }
+            }
+        },
+        "Pet": {
+            "type": "object",
+            "required": [
+                "name", "tag"
+            ],
+            "properties": {
                 "name": {
                     "type": "string"
                 },


### PR DESCRIPTION
This patch provides following changes for swagger validator:

1. Validation of query parameters moved to PhoenixSwagger.Plug.Validate
plug as we can't validate them correctly with json schema.

2. Error fixed with validation of required fields of nested objects.