### PR TITLE
Add swagger path/operation DSL

### DIFF
--- a/lib/phoenix_swagger/path.ex
+++ b/lib/phoenix_swagger/path.ex
@@ -1,0 +1,255 @@
+defmodule PhoenixSwagger.Path do
+  @moduledoc """
+  Defines the swagger path DSL for specifying Controller actions.
+  This module should not be imported directly, it will be automatically imported
+   in the scope of a `swagger_path` macro body.
+
+  ## Examples
+
+      use PhoenixSwagger
+
+      swagger_path :index do
+        get "/users"
+        produces "application/json"
+        paging
+        parameter :id, :query, :integer, "user id", required: true
+        tag "Users"
+        response 200 "User resource" :User
+        response 404 "User not found"
+      end
+  """
+
+  defmodule Parameter do
+    @moduledoc """
+    A swagger parameter definition, similar to a `Schema`, but swagger defines
+    parameter name (and some other options) to be part of the parameter object itself.
+    See http://swagger.io/specification/#parameterObject
+    """
+
+    defstruct(
+      name: "",
+      in: "",
+      description: "",
+      required: false,
+      schema: nil,
+      type: nil,
+      format: nil,
+      allowEmptyValue: nil,
+      items: nil,
+      collectionFormat: nil,
+      default: nil,
+      maximum: nil,
+      exclusiveMaximum: nil,
+      minimum: nil,
+      exclusiveMinimum: nil,
+      maxLength: nil,
+      minLength: nil,
+      pattern: nil,
+      maxItems: nil,
+      minItems: nil,
+      uniqueItems: nil,
+      enum: nil,
+      multipleOf: nil)
+  end
+
+  defmodule ResponseObject do
+    @moduledoc """
+    A swagger response definition.
+    The response status (200, 404, etc.) is the key in the containing map.
+    See http://swagger.io/specification/#responseObject
+    """
+    defstruct description: "", schema: nil, headers: nil, examples: nil
+  end
+
+  defmodule OperationObject do
+    @moduledoc """
+    A swagger operation object ties together parameters, responses, etc.
+    See http://swagger.io/specification/#operationObject
+    """
+    defstruct(
+      tags: [],
+      summary: "",
+      description: "",
+      externalDocs: nil,
+      operationId: "",
+      consumes: nil,
+      produces: nil,
+      parameters: [],
+      responses: %{},
+      deprecated: nil,
+      security: nil)
+  end
+
+  defmodule PathObject do
+    @moduledoc """
+    The DSL builds paths out of individual operations, so this is a flattened version
+    of a swagger Path. The `nest` function will convert this to a nested map before final
+    conversion to a JSON map.
+    See http://swagger.io/specification/#pathsObject
+    """
+    defstruct path: "", verb: "", operation: %OperationObject{}
+  end
+
+  @doc "Initializes a Swagger Path DSL block with a get verb"
+  def get(path), do: %PathObject{path: path, verb: "get"}
+
+  @doc "Initializes a Swagger Path DSL block with a post verb"
+  def post(path), do: %PathObject{path: path, verb: "post"}
+
+  @doc "Initializes a Swagger Path DSL block with a put verb"
+  def put(path), do: %PathObject{path: path, verb: "put"}
+
+  @doc "Initializes a Swagger Path DSL block with a delete verb"
+  def delete(path), do: %PathObject{path: path, verb: "delete"}
+
+  @doc "Initializes a Swagger Path DSL block with a head verb"
+  def head(path), do: %PathObject{path: path, verb: "head"}
+
+  @doc "Initializes a Swagger Path DSL block with a options verb"
+  def options(path), do: %PathObject{path: path, verb: "options"}
+
+
+  @doc """
+  Adds the summary section to the operation of a swagger `%PathObject{}`
+  """
+  def summary(path = %PathObject{}, summary) do
+    put_in path.operation.summary, summary
+  end
+
+  @doc """
+  Adds the description section to the operation of a swagger `%PathObject{}`
+  """
+  def description(path = %PathObject{}, description) do
+    put_in path.operation.description, description
+  end
+
+  @doc """
+  Adds a mime-type to the consumes list of the operation of a swagger `%PathObject{}`
+  """
+  def consumes(path = %PathObject{}, mimetype) do
+    put_in path.operation.consumes, (path.operation.consumes || []) ++ [mimetype]
+  end
+
+  @doc """
+  Adds a mime-type to the produces list of the operation of a swagger `%PathObject{}`
+  """
+  def produces(path = %PathObject{}, mimetype) do
+    put_in path.operation.produces, (path.operation.produces || []) ++ [mimetype]
+  end
+
+  @doc """
+  Adds a tag to the operation of a swagger `%PathObject{}`
+  """
+  def tag(path = %PathObject{}, tag) do
+    put_in path.operation.tags, path.operation.tags ++ [tag]
+  end
+
+  @doc """
+  Adds the operationId section to the operation of a swagger `%PathObject{}`
+  """
+  def operation_id(path = %PathObject{}, id) do
+    put_in path.operation.operationId, id
+  end
+
+  @doc """
+  Defines multiple parameters for an operation with a custom DSL syntax
+
+  ## Example
+
+      swagger_path :create do
+        post "/api/v1/{team}/users"
+        summary "Create a new user"
+        parameters do
+          user :body, Schema.ref(:User), "user attributes"
+          team :path, :string, "Users team ID"
+        end
+        response 200, "OK", :User
+      end
+  """
+  defmacro parameters(path, [do: {:__block__, _, exprs}]) do
+    exprs
+    |> Enum.map(fn {name, line, args} -> {:parameter, line, [name | args]} end)
+    |> Enum.reduce(path, fn expr, acc ->
+         quote do unquote(acc) |> unquote(expr) end
+       end)
+  end
+
+  @doc """
+  Adds a parameter to the operation of a swagger `%PathObject{}`
+  """
+  def parameter(path = %PathObject{}, name, location, type, description, opts \\ []) do
+    param = %Parameter{
+      name: name,
+      in: location,
+      description: description
+    }
+    param = case location do
+      :body -> %{param | schema: type}
+      :path -> %{param | type: type, required: true}
+      _ -> %{param | type: type}
+    end
+    param = Map.merge(param, opts |> Enum.into(%{}, &translate_parameter_opt/1))
+    params = path.operation.parameters
+    put_in path.operation.parameters, params ++ [param]
+  end
+
+  defp translate_parameter_opt({:example, v}), do: {:"x-example", v}
+  defp translate_parameter_opt({:items, items_schema}) when is_list(items_schema) do
+     {:items, Enum.into(items_schema, %{})}
+  end
+  defp translate_parameter_opt({k, v}), do: {k, v}
+
+  @doc """
+  Adds page size, number and offset parameters to the operation of a swagger `%PathObject{}`
+
+  The names default to  "page_size" and "page" for ease of use with `scriviner_ecto`, but can be overridden.
+
+  ## Examples
+
+      get "/api/pets/"
+      paging
+      response 200, "OK"
+
+      get "/api/pets/dogs"
+      paging size: "page_size", number: "count"
+      response 200, "OK"
+
+      get "/api/pets/cats"
+      paging size: "limit", offset: "offset"
+      response 200, "OK"
+  """
+  def paging(path = %PathObject{}, opts \\ [size: "page_size", number: "page"]) do
+    Enum.reduce opts, path, fn
+      {:size, size}, path -> parameter(path, size, :query, :integer, "Number of elements per page", minimum: 1)
+      {:number, number}, path -> parameter(path, number, :query, :integer, "Number of the page", minimum: 1)
+      {:offset, offset}, path -> parameter(path, offset, :query, :integer, "Offset of first element in the page")
+    end
+  end
+
+  @doc """
+  Adds a response to the operation of a swagger `%PathObject{}`, without a schema
+  """
+  def response(path = %PathObject{}, status, description) do
+    resp = %ResponseObject{description: description}
+    put_in path.operation.responses[to_string(status)], resp
+  end
+
+  @doc """
+  Adds a parameter to the operation of a swagger `%PathObject{}`, with a schema
+  """
+  def response(path = %PathObject{}, status, description, schema) when is_atom(schema)  do
+    resp = %ResponseObject{description: description, schema: %{"$ref" => "#/definitions/#{schema}"}}
+    put_in path.operation.responses[to_string(status)], resp
+  end
+  def response(path = %PathObject{}, status, description, schema = %{}) do
+    resp = %ResponseObject{description: description, schema: schema}
+    put_in path.operation.responses[to_string(status)], resp
+  end
+
+  @doc """
+  Converts the `%PathObject{}` struct into the nested JSON form expected by swagger
+  """
+  def nest(path = %PathObject{}) do
+    %{path.path => %{path.verb => path.operation}}
+  end
+end

--- a/lib/phoenix_swagger/path.ex
+++ b/lib/phoenix_swagger/path.ex
@@ -2,7 +2,7 @@ defmodule PhoenixSwagger.Path do
   @moduledoc """
   Defines the swagger path DSL for specifying Controller actions.
   This module should not be imported directly, it will be automatically imported
-   in the scope of a `swagger_path` macro body.
+  in the scope of a `swagger_path` macro body.
 
   ## Examples
 

--- a/lib/phoenix_swagger/schema.ex
+++ b/lib/phoenix_swagger/schema.ex
@@ -38,7 +38,7 @@ defmodule PhoenixSwagger.Schema do
 
   @doc """
   Construct a schema reference, using name of definition in this swagger document,
-    or a complete path.
+  or a complete path.
 
   ## Example
 
@@ -459,7 +459,7 @@ defmodule PhoenixSwagger.Schema do
   Sets the schema/s for the items of an array.
   Use a single schema for arrays when each item should have the same schema.
   Use a list of schemas when the array represents a tuple, each element will be validated against
-   the corresponding schema in the `items` list.
+  the corresponding schema in the `items` list.
 
   ## Example
 
@@ -501,7 +501,7 @@ defmodule PhoenixSwagger.Schema do
 
   @doc """
   Boolean indicating that additional properties are allowed, or
-   a schema to be used for validating any additional properties not listed in `properties`.
+  a schema to be used for validating any additional properties not listed in `properties`.
   Default behaviour is to allow additional properties.
 
   ## Example

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -1,0 +1,166 @@
+defmodule PhoenixSwagger.PathTest do
+  use ExUnit.Case
+  use PhoenixSwagger
+
+  doctest PhoenixSwagger.Path
+
+  swagger_path :index do
+    get "/api/v1/users"
+    summary "Query for users"
+    description "Query for users with paging and filtering"
+    produces "application/json"
+    tag "Users"
+    operation_id "list_users"
+    paging
+    parameter "zipcode", :query, :string, "Address Zip Code", required: true, example: "90210"
+    parameter "include", :query, :array, "Related resources to include in response",
+                items: [type: :string, enum: [:organisation, :favourites, :purchases]],
+                collectionFormat: :csv
+    response 200, "OK", :Users
+    response 400, "Client Error"
+  end
+
+  swagger_path :create do
+    post "/api/v1/{team}/users"
+    summary "Create a new user"
+    consumes "application/json"
+    produces "application/json"
+    tag "Users"
+    parameters do
+      user :body, Schema.ref(:User), "user attributes"
+      team :path, :string, "Users team ID"
+    end
+    response 200, "OK", user_schema
+  end
+
+  def user_schema do
+    swagger_schema do
+      title "User"
+      description "A user of the application"
+      properties do
+        name :string, "Users name", required: true
+        id :string, "Unique identifier", required: true
+        address :string, "Home adress"
+      end
+    end
+  end
+
+  test "swagger_path_index produces expected swagger json" do
+    assert swagger_path_index() == %{
+      "/api/v1/users" => %{
+        "get" => %{
+          "produces" => ["application/json"],
+          "tags" => ["Users"],
+          "operationId" => "list_users",
+          "summary" => "Query for users",
+          "description" => "Query for users with paging and filtering",
+          "parameters" => [
+            %{
+              "description" => "Number of elements per page",
+              "in" => "query",
+              "name" => "page_size",
+              "required" => false,
+              "type" => "integer",
+              "minimum" => 1
+            },
+            %{
+              "description" => "Number of the page",
+              "in" => "query",
+              "name" => "page",
+              "required" => false,
+              "type" => "integer",
+              "minimum" => 1
+            },
+            %{
+              "description" => "Address Zip Code",
+              "in" => "query",
+              "name" => "zipcode",
+              "required" => true,
+              "type" => "string",
+              "x-example" => "90210"
+            },
+            %{
+              "collectionFormat" => "csv",
+              "description" => "Related resources to include in response",
+              "in" => "query",
+              "items" => %{
+                "type" => "string",
+                "enum" => ["organisation", "favourites", "purchases"]
+              },
+              "name" => "include",
+              "required" => false,
+              "type" => "array"
+            }
+          ],
+          "responses" => %{
+            "200" => %{
+              "description" => "OK",
+              "schema" =>  %{
+                "$ref" => "#/definitions/Users"
+              }
+            },
+            "400" => %{
+              "description" => "Client Error"
+            }
+          }
+        }
+      }
+    }
+  end
+
+  test "swagger_path_create produces expected swagger json" do
+    assert swagger_path_create() == %{
+      "/api/v1/{team}/users" => %{
+        "post" => %{
+          "consumes" => ["application/json"],
+          "description" => "",
+          "operationId" => "PhoenixSwagger.PathTest.create",
+          "parameters" => [
+            %{
+              "description" => "user attributes",
+              "in" => "body",
+              "name" => "user",
+              "required" => false,
+              "schema" => %{"$ref" => "#/definitions/User"},
+            },
+            %{
+              "description" => "Users team ID",
+              "in" => "path",
+              "name" => "team",
+              "required" => true,
+              "type" => "string"
+            }
+          ],
+          "produces" => ["application/json"],
+          "responses" => %{
+            "200" => %{
+              "description" => "OK",
+              "schema" => %{
+                "type" => "object",
+                "title" => "User",
+                "description" => "A user of the application",
+                "properties" => %{
+                  "address" => %{
+                    "description" => "Home adress",
+                    "type" => "string"
+                  },
+                  "id" => %{
+                    "description" => "Unique identifier",
+                    "type" => "string"
+                  },
+                  "name" => %{
+                    "description" => "Users name",
+                    "type" => "string"
+                  }
+                },
+                "required" => ["id", "name"]
+              }
+            }
+          },
+          "summary" => "Create a new user",
+          "tags" => ["Users"]
+        }
+      }
+    }
+  end
+end


### PR DESCRIPTION
 This PR adds the `PhoenixSwagger.swagger_path` macro, which is similar to the existing swagger_model macro.

 - swagger_path defines a function `swagger_path_<action>` which when called produces a map
   that can be merged into the `paths` section of a swagger document.
 - `PhoenixSwagger.Path` module defines some structs for Parameter, Response, Operation and Path
 - Similar to `PhoenixSwagger.Schema`, there are some functions for manipulating the structures,
   mostly for transforming a `%PathObject{}` struct through a pipeline.
 - Since defining parameters very common, there is a macro for `parameters` similar to schema `properties`.
 - Pagination parameter helper defaults parameter names to match [scriviner_ecto](https://github.com/drewolson/scrivener_ecto) convention
 - Test file `path_test.exs` demonstrates usage of `swagger_path` with `swagger_schema`
 - Not yet integrated into `Mix.Tasks.Phoenix.Swagger.Generate`


## Example:  
(more in https://github.com/mbuhot/phoenix_swagger/blob/path-dsl/test/path_test.exs)

```elixir
  swagger_path :index do
    get "/api/v1/users"
    summary "Query for users"
    description "Query for users with paging and filtering"
    produces "application/json"
    tag "Users"
    operation_id "list_users"
    paging
    parameter "zipcode", :query, :string, "Address Zip Code", required: true, example: "90210"
    parameter "include", :query, :array, "Related resources to include in response",
                items: [type: :string, enum: [:organisation, :favourites, :purchases]],
                collectionFormat: :csv
    response 200, "OK", :Users
    response 400, "Client Error"
  end
```

## Produces:

```json
{
  "/api/v1/users": {
    "get": {
      "tags": [
        "Users"
      ],
      "summary": "Query for users",
      "responses": {
        "400": {
          "description": "Client Error"
        },
        "200": {
          "schema": {
            "$ref": "#/definitions/Users"
          },
          "description": "OK"
        }
      },
      "produces": [
        "application/json"
      ],
      "parameters": [
        {
          "type": "integer",
          "required": false,
          "name": "page_size",
          "minimum": 1,
          "in": "query",
          "description": "Number of elements per page"
        },
        {
          "type": "integer",
          "required": false,
          "name": "page",
          "minimum": 1,
          "in": "query",
          "description": "Number of the page"
        },
        {
          "x-example": "90210",
          "type": "string",
          "required": true,
          "name": "zipcode",
          "in": "query",
          "description": "Address Zip Code"
        },
        {
          "type": "array",
          "required": false,
          "name": "include",
          "items": {
            "type": "string",
            "enum": [
              "organisation",
              "favourites",
              "purchases"
            ]
          },
          "in": "query",
          "description": "Related resources to include in response",
          "collectionFormat": "csv"
        }
      ],
      "operationId": "list_users",
      "description": "Query for users with paging and filtering"
    }
  }
}
```