### PR TITLE
Add JSON-API helpers

### DIFF
--- a/lib/phoenix_swagger.ex
+++ b/lib/phoenix_swagger.ex
@@ -50,6 +50,7 @@ defmodule PhoenixSwagger do
     quote do
       import PhoenixSwagger
       alias PhoenixSwagger.Schema
+      alias PhoenixSwagger.JsonApi
     end
   end
 

--- a/lib/phoenix_swagger/json_api.ex
+++ b/lib/phoenix_swagger/json_api.ex
@@ -1,0 +1,257 @@
+defmodule PhoenixSwagger.JsonApi do
+  @moduledoc """
+  This module defines a DSL for defining swagger definitions in a JSON-API conformant format.
+
+  ## Examples
+      use PhoenixSwagger
+
+      def swagger_definitions do
+        %{
+          UserResource: JsonApi.resource do
+            description "A user that may have one or more supporter pages."
+            attributes do
+              phone :string, "Users phone number"
+              full_name :string, "Full name"
+              user_updated_at :string, "Last update timestamp UTC", format: "ISO-8601"
+              user_created_at :string, "First created timestamp UTC"
+              email :string, "Email", required: true
+              birthday :string, "Birthday in YYYY-MM-DD format"
+              address Schema.ref(:Address), "Users address"
+            end
+            link :self, "The link to this user resource"
+            relationship :posts
+          end,
+          Users: JsonApi.page(:UserResource),
+          User: JsonApi.single(:UserResource)
+        }
+      end
+
+      swagger_path :index do
+        get "/api/v1/users"
+        paging size: "page[size]", number: "page[number]"
+        response 200, "OK", Schema.ref(:Users)
+      end
+  """
+
+  alias PhoenixSwagger.Schema
+  require PhoenixSwagger
+
+  @doc """
+  Defines a schema for a top level json-api document with an array of resources as primary data.
+  The given `resource` should be the name of a JSON-API resource defined with the `resource/1` macro
+  """
+  def page(resource) do
+    %Schema {
+      type: :object,
+      description: "A page of [#{resource}](##{resource |> to_string |> String.downcase}) results",
+      properties: %{
+        meta: %Schema {
+          type: :object,
+          properties: %{
+            "total-pages": %Schema {
+              type: :integer,
+              description: "The total number of pages available"
+            },
+            "total-count": %Schema {
+              type: :integer,
+              description: "The total number of items available"
+            }
+          }
+        },
+        links: %Schema {
+          type:  :object,
+          properties: %{
+            self: %Schema {
+              type:  :string,
+              description:  "Link to this page of results"
+            },
+            prev: %Schema {
+              type:  [:string, "null"],
+              description:  "Link to the previous page of results"
+            },
+            next: %Schema {
+              type:  [:string, "null"],
+              description:  "Link to the next page of results"
+            },
+            last: %Schema {
+              type:  :string,
+              description:  "Link to the last page of results"
+            },
+            first: %Schema {
+              type:  :string,
+              description:  "Link to the first page of results"
+            }
+          }
+        },
+        data: %Schema {
+          type:  :array,
+          description:  "Content with [#{resource}](##{resource |> to_string |> String.downcase}) objects",
+          items: %Schema {
+            "$ref": "#/definitions/#{resource}"
+          }
+        }
+      },
+      required:  [:data]
+    }
+    |> PhoenixSwagger.to_json()
+  end
+
+  @doc """
+  Defines a schema for a top level json-api document with a single primary data resource.
+  The given `resource` should be the name of a JSON-API resource defined with the `resource/1` macro
+  """
+  def single(resource) do
+    %Schema {
+      type: :object,
+      description: "A JSON-API document with a single [#{resource}](##{resource |> to_string |> String.downcase}) resource",
+      properties: %{
+        links: %Schema {
+          type:  :object,
+          properties: %{
+            self: %Schema {
+              type:  :string,
+              description:  "the link that generated the current response document."
+            }
+          }
+        },
+        data: %Schema {
+          "$ref": "#/definitions/#{resource}"
+        },
+        included: %Schema {
+          type: :array,
+          description: "Included resources",
+          items: %Schema{}
+        }
+      },
+      required:  [:data]
+    }
+    |> PhoenixSwagger.to_json()
+  end
+
+  @doc """
+  Defines a schema for a JSON-API resource, without the enclosing top-level document.
+  """
+  defmacro resource([do: {:__block__, _, exprs}]) do
+    schema = quote do
+      %Schema {
+        type: :object,
+        properties: %{
+          type: %Schema{type: :string, description: "The JSON-API resource type"},
+          id: %Schema{type: :string, description: "The JSON-API resource ID"},
+          relationships: %Schema{type: :object, properties: %{}},
+          links: %Schema{type: :object, properties: %{}},
+          attributes: %Schema{
+            type: :object,
+            properties: %{}
+          }
+        }
+      }
+    end
+
+    body = Enum.reduce(exprs, schema, fn expr, acc ->
+      quote do unquote(acc) |> unquote(expr) end
+    end)
+
+    quote do
+      (fn ->
+        import PhoenixSwagger.JsonApi
+        import PhoenixSwagger.Schema
+        unquote(body)
+        |> PhoenixSwagger.to_json()
+      end).()
+    end
+  end
+
+  @doc """
+  Defines a block of attributes for a JSON-API resource.
+  Within this block, each function call will be translated into a
+  call to the `PhoenixSwagger.JsonApi.attribute` function.
+
+  ## Example
+
+      description("A User")
+      attributes do
+        name :string, "Full name of the user", required: true
+        dateOfBirth :string, "Date of Birth", format: "ISO-8601", required: false
+      end
+
+  translates to:
+
+      description("A User")
+      |> attribute(:name, :string, "Full name of the user", required: true)
+      |> attribute(:dateOfBirth, :string, "Date of Birth", format: "ISO-8601", required: false)
+  """
+  defmacro attributes(model, [do: {:__block__, _, attrs}]) do
+    attrs
+    |> Enum.map(fn {name, line, args} -> {:attribute, line, [name | args]} end)
+    |> Enum.reduce(model, fn next, pipeline ->
+         quote do
+           unquote(pipeline) |> unquote(next)
+         end
+       end)
+  end
+
+  @doc """
+  Defines an attribute in a JSON-API schema.
+
+  Name, type and description are accepted as positional arguments, but any other
+  schema properties can be set through the trailing keyword arguments list.
+  As a convenience, required: true can be passed in the keyword args, causing the
+   name of this attribute to be added to the "required" list of the attributes schema.
+  """
+  def attribute(model, name, type, description, opts \\ [])
+  def attribute(model, name, type, description, opts) when is_atom(type) do
+    attribute(model, name, %Schema{type: type}, description, opts)
+  end
+  def attribute(model = %Schema{}, name, type = %Schema{}, description, opts) do
+    {required?, opts} = Keyword.pop(opts, :required)
+    attr_schema = struct!(type, [description: description] ++ opts)
+    model = put_in(model.properties.attributes.properties[name], attr_schema)
+
+    required = case {model.properties.attributes.required, required?} do
+      {nil, true} -> [name]
+      {r, true} -> r ++ [name]
+      {r, _} -> r
+    end
+
+    put_in model.properties.attributes.required, required
+  end
+
+  @doc """
+  Defines a link with name and description
+  """
+  def link(model = %Schema{}, name, description) do
+    put_in(
+      model.properties.links.properties[name],
+      %Schema{type: :string, description: description}
+    )
+  end
+
+  @doc """
+  Defines a relationship
+  """
+  def relationship(model = %Schema{}, name) do
+    put_in(
+      model.properties.relationships.properties[name],
+      %Schema{
+        type: :object,
+        properties: %{
+          links: %Schema{
+            type: :object,
+            properties: %{
+              self: %Schema{type: :string, description: "Relationship link for #{name}"},
+              related: %Schema{type: :string, description: "Related #{name} link"}
+            }
+          },
+          data: %Schema{
+            type: :object,
+            properties: %{
+              id: %Schema{type: :string, description: "Related #{name} resource id"},
+              type: %Schema{type: :string, description: "Type of related #{name} resource"}
+            }
+          }
+        }
+      }
+    )
+  end
+end

--- a/test/json_api_test.exs
+++ b/test/json_api_test.exs
@@ -1,0 +1,147 @@
+defmodule PhoenixSwagger.JsonApiTest do
+  use ExUnit.Case
+  use PhoenixSwagger
+
+  doctest PhoenixSwagger.JsonApi
+
+  def swagger_definitions do
+    %{
+      UserResource: JsonApi.resource do
+        description "A user that may have one or more supporter pages."
+        attributes do
+          phone :string, "Users phone number"
+          full_name :string, "Full name"
+          user_updated_at :string, "Last update timestamp UTC", format: "ISO-8601"
+          user_created_at :string, "First created timestamp UTC"
+          email :string, "Email", required: true
+          birthday :string, "Birthday in YYYY-MM-DD format"
+          address Schema.ref(:Address), "Users address"
+        end
+        link :self, "The link to this user resource"
+        relationship :posts
+      end,
+      Users: JsonApi.page(:UserResource),
+      User: JsonApi.single(:UserResource)
+    }
+  end
+
+  test "produces expected paginated users schema" do
+    users_schema = swagger_definitions[:Users]
+    assert users_schema == %{
+      "description" => "A page of [UserResource](#userresource) results",
+      "properties" => %{
+        "data" => %{
+          "description" => "Content with [UserResource](#userresource) objects",
+          "items" => %{"$ref" => "#/definitions/UserResource"},
+          "type" => "array"
+        },
+        "links" => %{
+          "properties" => %{
+            "first" => %{"description" => "Link to the first page of results", "type" => "string"},
+            "last" => %{"description" => "Link to the last page of results", "type" => "string"},
+            "next" => %{"description" => "Link to the next page of results", "type" => ["string", "null"]},
+            "prev" => %{"description" => "Link to the previous page of results", "type" => ["string", "null"]},
+            "self" => %{"description" => "Link to this page of results", "type" => "string"}
+          },
+          "type" => "object"
+        },
+        "meta" => %{
+          "properties" => %{
+            "total-pages" => %{
+              "description" => "The total number of pages available", "type" => "integer"
+            },
+            "total-count" => %{
+              "description" => "The total number of items available", "type" => "integer"
+            }
+          },
+          "type" => "object"
+        }
+      },
+      "required" => ["data"],
+      "type" => "object"
+    }
+  end
+
+  test "produces expected user top level schema" do
+    user_schema = swagger_definitions[:User]
+    assert user_schema == %{
+      "description" => "A JSON-API document with a single [UserResource](#userresource) resource",
+      "properties" => %{
+        "data" => %{
+          "$ref" => "#/definitions/UserResource"
+        },
+        "links" => %{
+          "properties" => %{
+            "self" => %{
+              "description" => "the link that generated the current response document.",
+              "type" => "string"
+            }
+          },
+          "type" => "object"
+        },
+        "included" => %{
+          "description" => "Included resources",
+          "type" => "array",
+          "items" => %{}
+        }
+      },
+      "required" => ["data"],
+      "type" => "object"
+    }
+  end
+
+  test "produces expected user resource schema" do
+    user_resource_schema = swagger_definitions[:UserResource]
+    assert user_resource_schema == %{
+      "description" => "A user that may have one or more supporter pages.",
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"description" => "The JSON-API resource ID", "type" => "string"},
+        "type" => %{"description" => "The JSON-API resource type", "type" => "string"},
+        "attributes" => %{
+          "type" => "object",
+          "properties" => %{
+            "address" => %{"$ref" => "#/definitions/Address", "description" => "Users address"},
+            "birthday" => %{ "description" => "Birthday in YYYY-MM-DD format", "type" => "string"},
+            "email" => %{"description" => "Email", "type" => "string"},
+            "full_name" => %{"description" => "Full name", "type" => "string"},
+            "phone" => %{"description" => "Users phone number", "type" => "string"},
+            "user_created_at" => %{"description" => "First created timestamp UTC", "type" => "string"},
+            "user_updated_at" => %{"description" => "Last update timestamp UTC", "type" => "string", "format" => "ISO-8601"}
+          },
+          "required" => ["email"]
+        },
+        "links" => %{
+          "type" => "object",
+          "properties" => %{
+            "self" => %{"description" => "The link to this user resource", "type" => "string"}
+          }
+        },
+        "relationships" => %{
+          "type" => "object",
+          "properties" => %{
+            "posts" => %{
+              "type" => "object",
+              "properties" => %{
+                "data" => %{
+                  "type" => "object",
+                  "properties" => %{
+                    "id" => %{"description" => "Related posts resource id", "type" => "string"},
+                    "type" => %{"description" => "Type of related posts resource", "type" => "string"}
+                  }
+                },
+                "links" => %{
+                  "type" => "object",
+                  "properties" => %{
+                    "related" => %{"description" => "Related posts link", "type" => "string"},
+                    "self" => %{"description" => "Relationship link for posts", "type" => "string"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  end
+end


### PR DESCRIPTION
This adds a helper module for defining swagger schemas for [JSON:API](http://jsonapi.org) apis.
The example below shows how much boilerplate is saved by using the `PhoenixSwagger.JsonApi` module vs maintaining a raw JSON swagger file.

Example:

```elixir
use PhoenixSwagger

def swagger_definitions do
  %{
    UserResource: JsonApi.resource do
      description "A user that may have one or more supporter pages."
      attributes do
        phone :string, "Users phone number"
        full_name :string, "Full name"
        user_updated_at :string, "Last update timestamp UTC", format: "ISO-8601"
        user_created_at :string, "First created timestamp UTC"
        email :string, "Email", required: true
        birthday :string, "Birthday in YYYY-MM-DD format"
        address Schema.ref(:Address), "Users address"
      end
      link :self, "The link to this user resource"
      relationship :posts
    end,
    Users: JsonApi.page(:UserResource),
    User: JsonApi.single(:UserResource)
  }
end

swagger_path :index do
  get "/api/v1/users"
  paging size: "page[size]", number: "page[number]"
  response 200, "OK", Schema.ref(:Users)
end
```

Producing:

```json
{
  "Users": {
    "type": "object",
    "required": [
      "data"
    ],
    "properties": {
      "meta": {
        "type": "object",
        "properties": {
          "total-pages": {
            "type": "integer",
            "description": "The total number of pages available"
          },
          "total-count": {
            "type": "integer",
            "description": "The total number of items available"
          }
        }
      },
      "links": {
        "type": "object",
        "properties": {
          "self": {
            "type": "string",
            "description": "Link to this page of results"
          },
          "prev": {
            "type": [
              "string",
              "null"
            ],
            "description": "Link to the previous page of results"
          },
          "next": {
            "type": [
              "string",
              "null"
            ],
            "description": "Link to the next page of results"
          },
          "last": {
            "type": "string",
            "description": "Link to the last page of results"
          },
          "first": {
            "type": "string",
            "description": "Link to the first page of results"
          }
        }
      },
      "data": {
        "type": "array",
        "items": {
          "$ref": "#/definitions/UserResource"
        },
        "description": "Content with [UserResource](#userresource) objects"
      }
    },
    "description": "A page of [UserResource](#userresource) results"
  },
  "UserResource": {
    "type": "object",
    "properties": {
      "type": {
        "type": "string",
        "description": "The JSON-API resource type"
      },
      "relationships": {
        "type": "object",
        "properties": {
          "posts": {
            "type": "object",
            "properties": {
              "links": {
                "type": "object",
                "properties": {
                  "self": {
                    "type": "string",
                    "description": "Relationship link for posts"
                  },
                  "related": {
                    "type": "string",
                    "description": "Related posts link"
                  }
                }
              },
              "data": {
                "type": "object",
                "properties": {
                  "type": {
                    "type": "string",
                    "description": "Type of related posts resource"
                  },
                  "id": {
                    "type": "string",
                    "description": "Related posts resource id"
                  }
                }
              }
            }
          }
        }
      },
      "links": {
        "type": "object",
        "properties": {
          "self": {
            "type": "string",
            "description": "The link to this user resource"
          }
        }
      },
      "id": {
        "type": "string",
        "description": "The JSON-API resource ID"
      },
      "attributes": {
        "type": "object",
        "required": [
          "email"
        ],
        "properties": {
          "user_updated_at": {
            "type": "string",
            "format": "ISO-8601",
            "description": "Last update timestamp UTC"
          },
          "user_created_at": {
            "type": "string",
            "description": "First created timestamp UTC"
          },
          "phone": {
            "type": "string",
            "description": "Users phone number"
          },
          "full_name": {
            "type": "string",
            "description": "Full name"
          },
          "email": {
            "type": "string",
            "description": "Email"
          },
          "birthday": {
            "type": "string",
            "description": "Birthday in YYYY-MM-DD format"
          },
          "address": {
            "description": "Users address",
            "$ref": "#/definitions/Address"
          }
        }
      }
    },
    "description": "A user that may have one or more supporter pages."
  },
  "User": {
    "type": "object",
    "required": [
      "data"
    ],
    "properties": {
      "links": {
        "type": "object",
        "properties": {
          "self": {
            "type": "string",
            "description": "the link that generated the current response document."
          }
        }
      },
      "included": {
        "type": "array",
        "items": {},
        "description": "Included resources"
      },
      "data": {
        "$ref": "#/definitions/UserResource"
      }
    },
    "description": "A JSON-API document with a single [UserResource](#userresource) resource"
  }
}
```