### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,45 @@ def swagger_definitions do
 end
 ```
 
+## JSON:API Helpers
+
+The `PhoenixSwagger.JsonApi` module provides helpers for constructing JSON:API schemas easily.
+`PhoenixSwagger.JsonApi.resource/1` describes a JSON:API [resource object](http://jsonapi.org/format/#document-resource-objects).
+`PhoenixSwagger.JsonApi.page/1` and `PhoenixSwagger.JsonApi.single/1` can then be used to wrap a resource in a JSON:API [top level object](http://jsonapi.org/format/#document-top-level)
+
+Example:
+
+```elixir
+use PhoenixSwagger
+
+def swagger_definitions do
+  %{
+    UserResource: JsonApi.resource do
+      description "A user that may have one or more supporter pages."
+      attributes do
+        phone :string, "Users phone number"
+        full_name :string, "Full name"
+        user_updated_at :string, "Last update timestamp UTC", format: "ISO-8601"
+        user_created_at :string, "First created timestamp UTC"
+        email :string, "Email", required: true
+        birthday :string, "Birthday in YYYY-MM-DD format"
+        address Schema.ref(:Address), "Users address"
+      end
+      link :self, "The link to this user resource"
+      relationship :posts
+    end,
+    Users: JsonApi.page(:UserResource),
+    User: JsonApi.single(:UserResource)
+  }
+end
+
+swagger_path :index do
+  get "/api/v1/users"
+  paging size: "page[size]", number: "page[number]"
+  response 200, "OK", Schema.ref(:Users)
+end
+```
+
 ## Generate Swagger File
 
 After adding swagger spec to you controllers, recompile your app `mix phoenix.server`, then run the `phoenix.swagger.generate`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dependencies in the `mix.exs` file:
 
 ```elixir
 def deps do
-  [{:phoenix_swagger, "~> 0.3.0"}]
+  [{:phoenix_swagger, "~> 0.4.0"}]
 end
 ```
 
@@ -27,43 +27,55 @@ Now you can use `phoenix_swagger` to generate `swagger-ui` file for you applicat
 
 ## Usage
 
-To generate [Info Object](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#infoObject)
-you must provide `swagger_info/0` function in your `mix.exs` file. This function returns
-a keyword list that contains `Info Object` fields:
+The outline of the swagger document should be returned from a `swagger_info/0` function
+defined in your phoenix `Router.ex` module.
 
 ```elixir
-def swagger_info do
-  [version: "0.0.0", title: "My awesome phoenix application"]
+defmodule MyApp.Router do
+  use MyApp.Web, :router
+
+  pipeline :api do
+    plug :accepts, ["json"]
+  end
+
+  scope "/api", MyApp do
+    pipe_through :api
+    resources "/users", UserController
+  end
+
+  def swagger_info do
+    %{
+      info: %{
+        version: "1.0",
+        title: "My App"
+      }    
+    }
+  end
 end
 ```
 
 The `version` and `title` are mandatory fields. By default the `version` will be `0.0.1`
-and the `title` will be `<enter your title>` if you will not provide `swagger_info/0`
+and the `title` will be `<enter your title>` if you do not provide `swagger_info/0`
 function.
 
-Fields that can be in the `swagger_info`:
+See the [swaggerObject specification](http://swagger.io/specification/#swaggerObject) for details
+of other information that can be included.
 
-Name           | Required | Type                                   | Default value
--------------- | -------- | -------------------------------------- | -------------
-title          | true     | string                                 | `<enter your title>`
-version        | true     | string                                 | `0.0.1`
-description    | false    | string                                 |                                          
-termsOfService | false    | string                                 |                    
-contact        | false    | [name: "...", url: "...", email:"..."] |                    
-license        | false    | [name: "...", url: "..."]              |                      
 
-`PhoenixSwagger` provides `swagger_model/2` macro that generates swagger specification
-for the certain phoenix controller.
+## Swagger Path DSL
+
+`PhoenixSwagger` provides `swagger_path/2` macro that generates swagger specification
+for the certain phoenix controller action.
 
 Example:
 
 ```elixir
 use PhoenixSwagger
 
-swagger_model :index do
-  description "Short description"
-  parameter :query, :id, :integer, :required, "Property id"
-  responses 200, "Description"
+swagger_path :index do
+  get "/posts"
+  description "List blog posts"
+  responses 200, "Success"
 end
 
 def index(conn, _params) do
@@ -72,60 +84,72 @@ def index(conn, _params) do
 end
 ```
 
-The `swagger_model` macro takes two parameters:
+The `swagger_path` macro takes two parameters:
 
 * Name of controller action;
-* `do` block that contains `swagger` definitions.
+* `do` block that contains the `swagger` specification for the controller action.
 
-The `PhoenixSwagger` supports three definitions:
+Within the do-end block, the DSL provided by the `PhoenixSwagger.Path` module can be used.
+The DSL always starts with one of the `get`, `put`, `post`, `delete`, `head`, `options` functions,
+followed by any functions with first argument being a `PhoenixSwagger.Path.PathObject` struct.
 
-1. The `description` takes one elixir's `String` and provides short description for the
-given controller action.
-
-2. The `parameter` provides description of the routing parameter for the given action and
-may take five parameters:
-
-* The location of the parameter. Possible values are `query`, `header`, `path`, `formData` or `body`. [required];
-* The name of the parameter. [required];
-* The type of the parameter. Allowed only [swagger data types](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#data-types
-) [required];
-* Determines whether this parameter is mandatory, just remove it if a parameter non-required;
-* Description of a parameter. Can be elixir's `String` or function/0 that returns elixir's string;
-
-Note that order of parameters is important now.
-
-And the third definition is `responses` that takes three parameters (third parameter is not mandatory)
-and generates definition of the response for the given controller action. The first argument is http
-status code and has `:integer` data type. The second is the short description of the response. The third
-non-mandatory field is a schema of the response. It must be elixir `function/0` that returns a map in a
-swagger schema format.
-
-For example:
+Example:
 
 ```elixir
-use PhoenixSwagger
-
-swagger_model :get_person do
-  description "Get persons according to the age"
-  parameter :query, :id, :integer, :required
-  responses 200, "Description", schema
-end
-
-def schema do
-  %{type: :array, title: "Persons",
-    items:
-      %{title: "Person", type: :object, properties: %{ name: %{type: :string}}}
-   }
+swagger_path :index do
+  get "/api/v1/{org_id}/users"
+  summary "Query for users"
+  description "Query for users. This operation supports with paging and filtering"
+  produces "application/json"
+  tag "Users"
+  operation_id "list_users"
+  paging
+  parameters do
+    org_id :path, :string, "Organization ID", required: true
+    zipcode :query, :string, "Address Zip Code", required: true, example: "90210"
+    include :query, :array, "Related resources to include in response",
+              items: [type: :string, enum: [:organisation, :favourites, :purchases]],
+              collectionFormat: :csv
   end
-
-def get_person_schema(conn, _params) do
-    ...
-    ...
-    ...
+  response 200, "OK", Schema.ref(:Users)
+  response 400, "Client Error"
 end
 ```
 
-That's all. Recompile your app `mix phoenix.server`, then run the `phoenix.swagger.generate`
+## Swagger Schema DSL
+
+Response schema definitions are placed in a `swagger_definitions/0` function within each controller module.
+This function should return a map in the format of a swagger [definitionsObject](http://swagger.io/specification/#definitionsObject).
+
+The `swagger_schema/2` macro can be used to build a schema definition using the functions provided by the `PhoenixSwagger.Schema` module.
+
+Example:
+
+```elixir
+def swagger_definitions do
+  %{
+    User: swagger_schema do
+      title "User"
+      description "A user of the application"
+      properties do
+        name :string, "Users name", required: true
+        id :string, "Unique identifier", required: true
+        address :string, "Home address"
+      end
+    end,
+    Users: swagger_schema do
+      title "Users"
+      description "A collection of Users"
+      type :array
+      items Schema.ref(:User)
+    end
+  }
+end
+```
+
+## Generate Swagger File
+
+After adding swagger spec to you controllers, recompile your app `mix phoenix.server`, then run the `phoenix.swagger.generate`
 mix task for the `swagger-ui` json file generation into directory with `phoenix` application:
 
 ```
@@ -137,6 +161,14 @@ To generate `swagger` file with the custom name/place, pass it to the main mix t
 
 ```
 mix phoenix.swagger.generate ~/my-phoenix-api.json
+```
+
+If the project contains multiple `Router` modules, you can generate a swagger file for each one by specifying the router module as an argument to `mix phoenix.swagger.generate`:
+
+```
+mix phoenix.swagger.generate booking-api.json -r MyApp.BookingRouter
+mix phoenix.swagger.generate reports-api.json -r MyApp.ReportsRouter
+mix phoenix.swagger.generate admin-api.json -r MyApp.AdminRouter
 ```
 
 For more informantion, you can find `swagger` specification [here](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md).

--- a/mix.exs
+++ b/mix.exs
@@ -1,15 +1,22 @@
 defmodule PhoenixSwagger.Mixfile do
   use Mix.Project
 
+  @version "0.4.0"
+
   def project do
     [app: :phoenix_swagger,
-     version: "0.3.3",
+     version: @version,
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),
      description: description(),
-     package: package()]
+     package: package(),
+
+     #Docs
+     source_url: "https://github.com/xerions/phoenix_swagger",
+     homepage_url: "https://github.com/xerions/phoenix_swagger",
+     docs: [extras: ["README.md"], main: "readme", source_ref: "v#{@version}"]]
   end
 
   # Configuration for the OTP application
@@ -33,7 +40,8 @@ defmodule PhoenixSwagger.Mixfile do
     [
         {:poison, "~> 1.5 or ~> 2.0"},
         {:ex_json_schema, "~> 0.5.1", optional: :true},
-        {:plug, "~> 1.1"}
+        {:plug, "~> 1.1"},
+        {:ex_doc, "~> 0.14", only: :dev, runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"ex_json_schema": {:hex, :ex_json_schema, "0.5.5", "d8d4c3f47b86c9e634e124d518b290dda82a8b94dcc314e45af10042fc369361", [:mix], []},
+%{"earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "ex_json_schema": {:hex, :ex_json_schema, "0.5.5", "d8d4c3f47b86c9e634e124d518b290dda82a8b94dcc314e45af10042fc369361", [:mix], []},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
   "plug": {:hex, :plug, "1.3.0", "6e2b01afc5db3fd011ca4a16efd9cb424528c157c30a44a0186bcc92c7b2e8f3", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}


### PR DESCRIPTION
 - Readme now shows examples using new DSL
 - Added ex_doc so HTML docs can be generated and published to hexdocs
 - Bumped version number to 0.4.0 since the DSL has changed