### PR TITLE
Support response examples in path DSL

### DIFF
--- a/test/json_api_test.exs
+++ b/test/json_api_test.exs
@@ -26,7 +26,7 @@ defmodule PhoenixSwagger.JsonApiTest do
   end
 
   test "produces expected paginated users schema" do
-    users_schema = swagger_definitions[:Users]
+    users_schema = swagger_definitions()[:Users]
     assert users_schema == %{
       "description" => "A page of [UserResource](#userresource) results",
       "properties" => %{
@@ -63,7 +63,7 @@ defmodule PhoenixSwagger.JsonApiTest do
   end
 
   test "produces expected user top level schema" do
-    user_schema = swagger_definitions[:User]
+    user_schema = swagger_definitions()[:User]
     assert user_schema == %{
       "description" => "A JSON-API document with a single [UserResource](#userresource) resource",
       "properties" => %{
@@ -91,7 +91,7 @@ defmodule PhoenixSwagger.JsonApiTest do
   end
 
   test "produces expected user resource schema" do
-    user_resource_schema = swagger_definitions[:UserResource]
+    user_resource_schema = swagger_definitions()[:UserResource]
     assert user_resource_schema == %{
       "description" => "A user that may have one or more supporter pages.",
       "type" => "object",

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -16,7 +16,7 @@ defmodule PhoenixSwagger.PathTest do
     parameter "include", :query, :array, "Related resources to include in response",
                 items: [type: :string, enum: [:organisation, :favourites, :purchases]],
                 collectionFormat: :csv
-    response 200, "OK", :Users
+    response 200, "OK", :Users, example: %{id: 1, name: "Joe", email: "joe@gmail.com"}
     response 400, "Client Error"
   end
 
@@ -96,6 +96,13 @@ defmodule PhoenixSwagger.PathTest do
               "description" => "OK",
               "schema" =>  %{
                 "$ref" => "#/definitions/Users"
+              },
+              "examples" => %{
+                "application/json" => %{
+                  "email" => "joe@gmail.com",
+                  "id" => 1,
+                  "name" => "Joe"
+                }
               }
             },
             "400" => %{


### PR DESCRIPTION
Add support for `examples` and `headers` keyword options in `response` (http://swagger.io/specification/#responseObject)

```elixir
swagger_path :index do
  get "/api/v1/users"
  produces "application/json"
  response 200, "OK", :Users, example: %{id: 1, name: "Joe", email: "joe@gmail.com"}
end
```