### PR TITLE
Change alias to require in __using__ macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.1
+
+  * Fix compilation errors when using `PhoenixSwagger.JsonApi` macros
+
 # 0.4.0
 
   * Add `PhoenixSwagger.Schema` module that provides a structure which represents

--- a/lib/phoenix_swagger.ex
+++ b/lib/phoenix_swagger.ex
@@ -59,8 +59,8 @@ defmodule PhoenixSwagger do
   defmacro __using__(_) do
     quote do
       import PhoenixSwagger
-      alias PhoenixSwagger.Schema
-      alias PhoenixSwagger.JsonApi
+      require PhoenixSwagger.Schema, as: Schema
+      require PhoenixSwagger.JsonApi, as: JsonApi
     end
   end
 


### PR DESCRIPTION
Fixes compilation errors caused by `PhoenixSwagger.JsonApi` module not required before using the JsonApi.resource macro.

The symptom is a for code such as:

```elixir
def swagger_definitions do
  %{
    UserResource: JsonApi.resource do
      title "UserResource"
      description "A user with a profile page"
      attributes do
        given_name :string, "The user's given name"
        email :string, "The user's email"
      end
    end
  }
end

```

```
== Compilation error on file lib/user_controller.ex ==
** (CompileError) lib/user_controller.ex:22: undefined function title/1
    (stdlib) lists.erl:1338: :lists.foreach/2
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
```

Not sure why this was working in the unit tests, but not working from a real project?
