### PR TITLE
Fix response without produces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.2
+
+  * Fix FunctionClauseError in `response` when no `produces` mime type defined on an operation.
+
 # 0.4.1
 
   * Fix compilation errors when using `PhoenixSwagger.JsonApi` macros

--- a/lib/phoenix_swagger/path.ex
+++ b/lib/phoenix_swagger/path.ex
@@ -270,6 +270,7 @@ defmodule PhoenixSwagger.Path do
       opt -> opt
     end)
   end
+  def expand_response_example(%PathObject{}, opts), do: opts
 
   @doc """
   Converts the `%PathObject{}` struct into the nested JSON form expected by swagger

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -4,6 +4,14 @@ defmodule PhoenixSwagger.PathTest do
 
   doctest PhoenixSwagger.Path
 
+  swagger_path :show do
+    get "/api/v1/users/{id}"
+    summary "Get a user"
+    description "Get a user by ID"
+    parameter "id", :path, :string, "User ID", required: true, example: "123"
+    response 200, "OK", :User
+  end
+
   swagger_path :index do
     get "/api/v1/users"
     summary "Query for users"
@@ -42,6 +50,37 @@ defmodule PhoenixSwagger.PathTest do
         address :string, "Home adress"
       end
     end
+  end
+
+  test "swagger_path_show produces expected swagger json" do
+    assert swagger_path_show() == %{
+      "/api/v1/users/{id}" => %{
+        "get" => %{
+          "description" => "Get a user by ID",
+          "operationId" => "PhoenixSwagger.PathTest.show",
+          "parameters" => [
+            %{
+              "description" => "User ID",
+              "in" => "path",
+              "name" => "id",
+              "required" => true,
+              "type" => "string",
+              "x-example" => "123"
+            }
+          ],
+          "responses" => %{
+            "200" => %{
+              "description" => "OK",
+              "schema" => %{
+                "$ref" => "#/definitions/User"
+              }
+            }
+          },
+          "summary" => "Get a user",
+          "tags" => ["PathTest"]
+        }
+      }
+    }
   end
 
   test "swagger_path_index produces expected swagger json" do


### PR DESCRIPTION
#53 introduced a regression where any time `response` was used without a preceding `produces`, a `FunctionClauseError` would happen.

This PR adds a test case and fixes the bug by adding another function clause on `expand_response_example` to handle this case.