### PR TITLE
Support multiple types for schema properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.3
+
+  * Allow for a list of types on `PhoenixSwagger.Schema.type`
+  * Fix not running all doctests
+
 # 0.4.2
 
   * Fix FunctionClauseError in `response` when no `produces` mime type defined on an operation.

--- a/lib/phoenix_swagger/json_api.ex
+++ b/lib/phoenix_swagger/json_api.ex
@@ -200,7 +200,7 @@ defmodule PhoenixSwagger.JsonApi do
    name of this attribute to be added to the "required" list of the attributes schema.
   """
   def attribute(model, name, type, description, opts \\ [])
-  def attribute(model, name, type, description, opts) when is_atom(type) do
+  def attribute(model, name, type, description, opts) when is_atom(type) or is_list(type) do
     attribute(model, name, %Schema{type: type}, description, opts)
   end
   def attribute(model = %Schema{}, name, type = %Schema{}, description, opts) do

--- a/lib/phoenix_swagger/schema.ex
+++ b/lib/phoenix_swagger/schema.ex
@@ -95,6 +95,7 @@ defmodule PhoenixSwagger.Schema do
       iex> alias PhoenixSwagger.Schema
       ...> %Schema{type: :object}
       ...> |> Schema.property(:name, :string, "Full name", required: true, maxLength: 256)
+      ...> |> Schema.property(:address, [:string, "null"], "Street Address")
       ...> |> Schema.property(:friends, Schema.array(:User), "Friends list", required: true)
       %PhoenixSwagger.Schema{
         type: :object,
@@ -103,6 +104,10 @@ defmodule PhoenixSwagger.Schema do
             type: :array,
             description: "Friends list",
             items: %PhoenixSwagger.Schema{"$ref": "#/definitions/User"}
+          },
+          address: %PhoenixSwagger.Schema{
+            type: [:string, "null"],
+            description: "Street Address"
           },
           name: %PhoenixSwagger.Schema{
             type: :string,
@@ -114,7 +119,7 @@ defmodule PhoenixSwagger.Schema do
       }
   """
   def property(model, name, type_or_schema, description, opts \\ [])
-  def property(model = %Schema{type: :object}, name, type, description, opts) when is_atom(type) do
+  def property(model = %Schema{type: :object}, name, type, description, opts) when is_atom(type) or is_list(type) do
     property(model, name, %Schema{type: type}, description, opts)
   end
   def property(model = %Schema{type: :object}, name, type = %Schema{}, description, opts) do

--- a/test/json_api_test.exs
+++ b/test/json_api_test.exs
@@ -3,6 +3,7 @@ defmodule PhoenixSwagger.JsonApiTest do
   use PhoenixSwagger
 
   doctest PhoenixSwagger.JsonApi
+  doctest PhoenixSwagger.Schema
 
   def swagger_definitions do
     %{
@@ -16,6 +17,7 @@ defmodule PhoenixSwagger.JsonApiTest do
           email :string, "Email", required: true
           birthday :string, "Birthday in YYYY-MM-DD format"
           address Schema.ref(:Address), "Users address"
+          gender [:string, "null"], "Gender"
         end
         link :self, "The link to this user resource"
         relationship :posts
@@ -105,6 +107,7 @@ defmodule PhoenixSwagger.JsonApiTest do
             "birthday" => %{ "description" => "Birthday in YYYY-MM-DD format", "type" => "string"},
             "email" => %{"description" => "Email", "type" => "string"},
             "full_name" => %{"description" => "Full name", "type" => "string"},
+            "gender" => %{"description" => "Gender", "type" => ["string", "null"]},
             "phone" => %{"description" => "Users phone number", "type" => "string"},
             "user_created_at" => %{"description" => "First created timestamp UTC", "type" => "string"},
             "user_updated_at" => %{"description" => "Last update timestamp UTC", "type" => "string", "format" => "ISO-8601"}


### PR DESCRIPTION
The JSON schema standard allows for multiple types assigned to a single type: https://spacetelescope.github.io/understanding-json-schema/reference/type.html

This adds the capability to have a list.

I've also added the Schema doctests as they weren't being run.