### PR TITLE
Fix #58 - Ignore routes with keyword list options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * Allow for a list of types on `PhoenixSwagger.Schema.type`
   * Fix not running all doctests
+  * Fix `ArgumentError` in `Phoenix.Swagger.Generate` when routing to plug with keyword opts [#58](https://github.com/xerions/phoenix_swagger/issues/58)
 
 # 0.4.2
 


### PR DESCRIPTION
Phoenix routes to a controller always have the controller action as the opts, eg :index
However Phoenix router can route to any plug, which can have any opts, often a keyword list.
This change causes any route without a single atom opts field to be ignored.