### PR TITLE
Remove match to allow custom swagger paths

### DIFF
--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -146,7 +146,7 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
   end
 
   defp get_swagger_path(%{controller: controller, swagger_fun: fun, path: path}) do
-    %{^path => _action} = apply(controller, fun, [])
+    apply(controller, fun, [])
   end
 
   defp merge_paths(path, swagger_map) do


### PR DESCRIPTION
I need to have the url for my endpoint in swagger be different than the url being generated by the Phoenix router.

I couldn't identify any reason we needed this match. If we remove the match, then we can specify any url when defining a swagger path.

``` elixir
  swagger_path :index do
    get "/anything/you_want/widgets"
```

