### PR TITLE
Skip applications with no Endpoints (Improves Umbrella support)

### DIFF
--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
       (Keyword.get(switches, :help)) ->
         usage()
       has_no_endpoint() ->
-        IO.puts "No Endpoint configured for app #{app_name()}, skipping."
+        IO.puts "Skipping app #{app_name()}, no Endpoint configured."
       true ->
         router = load_router(switches)
         output_file = Enum.at(params, 0, default_swagger_file_path())


### PR DESCRIPTION
In an umbrella app it's expected that not all applications will have Endpoints, this is a small PR to check if an application has a configured Endpoint before attempting to load it's router. 

In a sample umbrella with three applications, one of which uses phoenix:

Previous behavior:
``` 
> mix phoenix.swagger.generate
** (MatchError) no match of right hand side value: {:error, :nofile}
    lib/mix/tasks/swagger.generate.ex:68: Mix.Tasks.Phoenix.Swagger.Generate.load_router/1
    lib/mix/tasks/swagger.generate.ex:43: Mix.Tasks.Phoenix.Swagger.Generate.run/1
    (mix) lib/mix/task.ex:294: Mix.Task.run_task/3
    (mix) lib/mix/project.ex:312: Mix.Project.in_project/4
    (elixir) lib/file.ex:1162: File.cd!/2
    (mix) lib/mix/task.ex:394: anonymous fn/4 in Mix.Task.recur/1
    (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix) lib/mix/task.ex:393: Mix.Task.recur/1
```

New behavior:
```
> mix phoenix.swagger.generate
Skipping application_one, no Endpoint configured.
Generated /some/path/to/swagger.json
Skipping application_three, no Endpoint configured.
```

Note that further work would be required to support _multiple_ Endpoints in a single umbrella environment, but having only one is a common enough pattern to be useful. 