### PR TITLE
Schema examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.1
+
+  * Allow schemas to include an example
+
 # 0.5.0
 
   * Include swagger-ui plug `PhoenixSwagger.Plug.SwaggerUI`

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ def swagger_definitions do
         id :string, "Unique identifier", required: true
         address :string, "Home address"
       end
+      example %{
+        name: "Joe",
+        id: "123",
+        address: "742 Evergreen Terrace"
+      }
     end,
     Users: swagger_schema do
       title "Users"

--- a/examples/simple/priv/static/swagger.json
+++ b/examples/simple/priv/static/swagger.json
@@ -291,6 +291,11 @@
           "description": "Email address"
         }
       },
+      "example": {
+        "name": "Joe",
+        "id": 123,
+        "email": "joe@gmail.com"
+      },
       "description": "A user of the app"
     }
   }

--- a/examples/simple/web/controllers/user_controller.ex
+++ b/examples/simple/web/controllers/user_controller.ex
@@ -16,6 +16,11 @@ defmodule Simple.UserController do
           inserted_at :string, "Creation timestamp", format: :datetime
           updated_at :string, "Update timestamp", format: :datetime
         end
+        example %{
+          id: 123,
+          name: "Joe",
+          email: "joe@gmail.com"
+        }
       end,
       UserRequest: swagger_schema do
         title "UserRequest"

--- a/lib/phoenix_swagger/schema.ex
+++ b/lib/phoenix_swagger/schema.ex
@@ -34,7 +34,8 @@ defmodule PhoenixSwagger.Schema do
     :items,
     :allOf,
     :properties,
-    :additionalProperties]
+    :additionalProperties,
+    :example]
 
   @doc """
   Construct a schema reference, using name of definition in this swagger document,
@@ -588,5 +589,27 @@ defmodule PhoenixSwagger.Schema do
   end
   def required(model = %Schema{type: :object}, names) when is_list(names) do
     %{model | required: names ++ (model.required || [])}
+  end
+
+  @doc """
+  Adds an example of the schema.
+
+    ## Example
+
+    iex> alias PhoenixSwagger.Schema
+    ...> %Schema{type: :object, properties: %{phone_number: %Schema{type: :string}}}
+    ...> |> Schema.example(%{phone_number: "555-123-456"})
+    %PhoenixSwagger.Schema{
+      type: :object,
+      properties: %{
+        phone_number: %PhoenixSwagger.Schema{
+          type: :string
+        }
+      },
+      example: %{phone_number: "555-123-456"}
+    }
+  """
+  def example(model = %Schema{}, example) do
+    %{model | example: example}
   end
 end


### PR DESCRIPTION
This PR adds support for supplying an example with each schema definition.

A single schema example is supported by the swagger spec: http://swagger.io/specification/#schemaObject

When given, swagger-ui will populate the `example value` text area with this example, making it easier to make POST requests from swagger-ui.