### PR TITLE
Do not assign a host if one has not been provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.5.1
 
   * Allow schemas to include an example
+  * Do not set a host if a url has not been provided
 
 # 0.5.0
 


### PR DESCRIPTION
In the swagger spec it states that
```
If the host is not included, the host serving the documentation is to be used (including the port)
```

This PR will change the host assignment to match the above spec where a host will not be provided in the resulting swagger.json if a URL is not provided.