### PR TITLE
Add discriminator schema field for polymorphic schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.5.1
 
   * Allow schemas to include an example
+  * Add support for `discriminator` in polymorphic schemas
   * Do not set a host if a url has not been provided
 
 # 0.5.0

--- a/lib/phoenix_swagger/schema.ex
+++ b/lib/phoenix_swagger/schema.ex
@@ -35,6 +35,7 @@ defmodule PhoenixSwagger.Schema do
     :allOf,
     :properties,
     :additionalProperties,
+    :discriminator,
     :example]
 
   @doc """
@@ -488,6 +489,8 @@ defmodule PhoenixSwagger.Schema do
 
   @doc """
   Used to combine multiple schemas, requiring a value to conform to all schemas.
+  Can be used in conjunction with `discriminator` to define polymorphic inheritance relationships.
+  See http://swagger.io/specification/#composition-and-inheritance--polymorphism--83
 
   ## Example
 
@@ -612,4 +615,40 @@ defmodule PhoenixSwagger.Schema do
   def example(model = %Schema{}, example) do
     %{model | example: example}
   end
+
+  @doc """
+  Specifies the name of a property that identifies the polymorphic schema for a JSON object.
+  The value of this property should be the name of this schema, or another schema that inherits
+  from this schema using `all_of`.
+  See http://swagger.io/specification/#composition-and-inheritance--polymorphism--83
+
+
+    ## Example
+
+    iex> alias PhoenixSwagger.Schema
+    ...> %Schema{}
+    ...> |> Schema.type(:object)
+    ...> |> Schema.title("Pet")
+    ...> |> Schema.property(:pet_type, :string, "polymorphic pet schema type", example: "Dog")
+    ...> |> Schema.discriminator(:pet_type)
+    %Schema{
+      type: :object,
+      title: "Pet",
+      properties: %{
+        pet_type: %Schema{
+          type: :string,
+          description: "polymorphic pet schema type",
+          example: "Dog"
+        }
+      },
+      discriminator: :pet_type,
+      required: [:pet_type]
+    }
+  """
+  def discriminator(model = %Schema{}, property_name) do
+    model
+    |> Map.put(:discriminator, property_name)
+    |> required(property_name)
+  end
+
 end


### PR DESCRIPTION
Adds the `discriminator` field to the `PhoenixSwagger.Schema` struct, as described in the swagger spec section [composition-and-inheritance](http://swagger.io/specification/#composition-and-inheritance--polymorphism--83)

As an example of usage, the "Pet" schema could be a base schema, extended by "Cat" and "Dog", using the "petType" field as discriminator:

```elixir
def swagger_definitions() do
  %{
    Pet: swagger_schema do
      discriminator "petType"
      properties do
        name :string, "Pets name", required: true
        petType :string, "Concrete pet type", required: true
      end
    end
    Cat: swagger_schema do
      description "A representation of a cat",
      all_of [
        Schema.ref(:Pet),
        swagger_schema do
          type :object
          properties do
            huntingSkill :string, "The measured skill for hunting",  required: true, default: "lazy",
              enum: ["clueless", "lazy", "adventurous", "aggressive"]
          end
        end
      ]
    end,
    Dog: swagger_schema do
      description "A representation of a dog"
      allOf [
        Schema.ref(:Pet),
        swagger_schema do
          type :object
          properties do
            packSize :integer, "the size of the pack the dog is from", required: true, format: "int32", default: 0, minimum: 0
          end
        end
      ]
    end
  }
end
```