### PR TITLE
Inline property schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.5.1
 
+  * Allow property schemas to be declared inline using `Schema.new` macro
   * Allow schemas to include an example
   * Do not set a host if a url has not been provided
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ def swagger_definitions do
         name :string, "Users name", required: true
         id :string, "Unique identifier", required: true
         address :string, "Home address"
+        preferences (Schema.new do
+          properties do
+            subscribe_to_mailing_list :boolean, "mailing list subscription", default: true
+            send_special_offers :boolean, "special offers list subscription", default: true
+          end
+        end)
       end
       example %{
         name: "Joe",

--- a/lib/phoenix_swagger.ex
+++ b/lib/phoenix_swagger.ex
@@ -122,7 +122,12 @@ defmodule PhoenixSwagger do
         "type" => "string"
       }
   """
-  defmacro swagger_schema([do: {:__block__, _, exprs}]) do
+  defmacro swagger_schema(block) do
+    exprs = case block do
+      [do: {:__block__, _, exprs}] -> exprs
+      [do: expr] -> [expr]
+    end
+
     acc = quote do %Schema{type: :object} end
     body = Enum.reduce(exprs, acc, fn expr, acc ->
       quote do unquote(acc) |> unquote(expr) end

--- a/lib/phoenix_swagger/json_api.ex
+++ b/lib/phoenix_swagger/json_api.ex
@@ -181,7 +181,12 @@ defmodule PhoenixSwagger.JsonApi do
       |> attribute(:name, :string, "Full name of the user", required: true)
       |> attribute(:dateOfBirth, :string, "Date of Birth", format: "ISO-8601", required: false)
   """
-  defmacro attributes(model, [do: {:__block__, _, attrs}]) do
+  defmacro attributes(model, block) do
+    attrs = case block do
+      [do: {:__block__, _, attrs}] -> attrs
+      [do: attr] -> [attr]
+    end
+    
     attrs
     |> Enum.map(fn {name, line, args} -> {:attribute, line, [name | args]} end)
     |> Enum.reduce(model, fn next, pipeline ->

--- a/lib/phoenix_swagger/path.ex
+++ b/lib/phoenix_swagger/path.ex
@@ -168,7 +168,12 @@ defmodule PhoenixSwagger.Path do
         response 200, "OK", :User
       end
   """
-  defmacro parameters(path, [do: {:__block__, _, exprs}]) do
+  defmacro parameters(path, block) do
+    exprs = case block do
+      [do: {:__block__, _, exprs}] -> exprs
+      [do: expr] -> [expr]
+    end
+
     exprs
     |> Enum.map(fn {name, line, args} -> {:parameter, line, [name | args]} end)
     |> Enum.reduce(path, fn expr, acc ->

--- a/lib/phoenix_swagger/schema.ex
+++ b/lib/phoenix_swagger/schema.ex
@@ -170,13 +170,13 @@ defmodule PhoenixSwagger.Schema do
         required: [:friends, :name]
       }
   """
-  def property(model, name, type_or_schema, description, opts \\ [])
+  def property(model, name, type_or_schema, description \\ nil, opts \\ [])
   def property(model = %Schema{type: :object}, name, type, description, opts) when is_atom(type) or is_list(type) do
     property(model, name, %Schema{type: type}, description, opts)
   end
   def property(model = %Schema{type: :object}, name, type = %Schema{}, description, opts) do
     {required?, opts} = Keyword.pop(opts, :required)
-    property_schema = struct!(type, [description: description] ++ opts)
+    property_schema = struct!(type, [description: type.description || description] ++ opts)
     properties = (model.properties || %{}) |> Map.put(name, property_schema)
     model = %{model | properties: properties}
     if required?, do: required(model, name), else: model

--- a/lib/phoenix_swagger/schema.ex
+++ b/lib/phoenix_swagger/schema.ex
@@ -158,7 +158,12 @@ defmodule PhoenixSwagger.Schema do
         required: [:name]
       }
   """
-  defmacro properties(model, [do: {:__block__, _, exprs}]) do
+  defmacro properties(model, block) do
+    exprs = case block do
+      [do: {:__block__, _, exprs}] -> exprs
+      [do: expr] -> [expr]
+    end
+    
     body =
       exprs
       |> Enum.map(fn {name, line, args} -> {:property, line, [name | args]} end)

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -48,6 +48,12 @@ defmodule PhoenixSwagger.PathTest do
         name :string, "Users name", required: true
         id :string, "Unique identifier", required: true
         address :string, "Home adress"
+        preferences (Schema.new do
+          properties do
+            subscribe_to_mailing_list :boolean, "mailing list subscription", default: true
+            send_special_offers :boolean, "special offers list subscription", default: true
+          end
+        end)
       end
     end
   end
@@ -196,6 +202,21 @@ defmodule PhoenixSwagger.PathTest do
                   "name" => %{
                     "description" => "Users name",
                     "type" => "string"
+                  },
+                  "preferences" => %{
+                    "properties" => %{
+                      "send_special_offers" => %{
+                        "default" => true,
+                        "description" => "special offers list subscription",
+                        "type" => "boolean"
+                      },
+                      "subscribe_to_mailing_list" => %{
+                        "default" => true,
+                        "description" => "mailing list subscription",
+                        "type" => "boolean"
+                      }
+                    },
+                    "type" => "object"
                   }
                 },
                 "required" => ["id", "name"]


### PR DESCRIPTION
This PR adds the ability to declare a `property` schema inline, where previously `Schema.ref` would have been required to reference a named schema.

A new macro `Schema.new` allows a `Schema` struct to be built using the `Schema` DSL, and passed anywhere that is expecting a `Schema` struct (parameters, properties, responses, etc..).

I also found that many macros that accepted a `do-end` block didn't work when given only a single expression, so I've updated them to handle that case too.

Example using inline property schemas, the `preferences` property doesn't need to be defined separately:

```elixir
    swagger_schema do
      title "User"
      description "A user of the application"
      properties do
        name :string, "Users name", required: true
        id :string, "Unique identifier", required: true
        address :string, "Home adress"
        preferences (Schema.new do
          properties do
            subscribe_to_mailing_list :boolean, "mailing list subscription", default: true
            send_special_offers :boolean, "special offers list subscription", default: true
          end
        end)
      end
    end
```