### PR TITLE
Configure github to treat priv/static as vendored code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+priv/static/* linguist-vendored


### PR DESCRIPTION
This should stop github from reporting the repo as a javascript repo.

From: https://github.com/github/linguist#overrides

> Use the linguist-vendored attribute to vendor or un-vendor paths.

```
$ cat .gitattributes
special-vendored-path/* linguist-vendored
jquery.js linguist-vendored=false
```
