### PR TITLE
update description of usage of validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,6 @@ Suppose you have following resource in your schema:
 ...
 ```
 
-Before usage of swagger validator, add the `PhoenixSwagger.Validator.Supervisor` to the supervisor tree of
-your application.
-
 The `phoenix_swagger` provides `PhoenixSwagger.Validator.parse_swagger_schema/1` API to load a swagger schema by
 the given path or list of paths. This API should be called during application startup to parse/load a swagger schema.
 


### PR DESCRIPTION
This patch updates description of usage of phoenix_swagger validator.
As we have no `PhoenixSwagger.Validator.Supervisor` anymore, let's
remove it from description.