### PR TITLE
Compile sources before generating swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ end
 
 ## Generate Swagger File
 
-After adding swagger spec to you controllers, recompile your app `mix phoenix.server`, then run the `phoenix.swagger.generate`
+After adding swagger spec to you controllers, run the `phoenix.swagger.generate`
 mix task for the `swagger-ui` json file generation into directory with `phoenix` application:
 
 ```

--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -29,6 +29,7 @@ defmodule Mix.Tasks.Phoenix.Swagger.Generate do
   defp default_router_module, do: Module.concat([app_module(), :Router])
 
   def run(args) do
+    Mix.Task.run("compile")
     Mix.Task.reenable("phoenix.swagger.generate")
     Code.append_path("#{app_path()}_build/#{Mix.env}/lib/#{app_name()}/ebin")
     {switches, params, _unknown} = OptionParser.parse(


### PR DESCRIPTION
It can be confusing when forgetting to run `mix compile` before `mix phoenix.swagger.generate` produces a swagger file that does not match the code.

This change automatically runs the "compile" mix task from the phoenix.swagger.generate task.