### PR TITLE
Swaggerui redirect / to /index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.6.1
 
   * Add `PhoenixSwagger.SchemaTest` module for response validation
+  * Swagger UI plug redirects / to /index.html automatically avoiding errors when fetching assets.
 
 # 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Add a swagger scope to your router, and forward all requests to SwaggerUI
     end
 ```
 
-Run the server with `mix phoenix.server` and browse to `localhost:8080/api/swagger/` (trailing slash required!),
+Run the server with `mix phoenix.server` and browse to `localhost:4000/api/swagger`,
 Swagger-ui should be shown with your swagger spec loaded.
 
 See the `examples/simple` project for a runnable example with swagger-ui.


### PR DESCRIPTION
With this change, a request to any of `/api/swagger`, `/api/swagger/` or `/api/swagger/index.html` should properly show the swagger ui.

Should resolve #86
Also related to #81 and #80

The strategy is to use a redirect from `/api/swagger` or `/api/swagger/` to `/api/swagger/index.html`.

Then when rendering the `index.html` EEx template, replace `index.html` with the `swagger.json` filename to get the swagger spec.

I've tested using the example app in the repo.

log output when requesting `/index.html`:

```
MACBOOK121:simple michael.buhot$ mix phoenix.server
[info] Running Simple.Endpoint with Cowboy using http://localhost:4000
[info] GET /api/swagger/index.html
[info] Sent 200 in 17ms
```