### PR TITLE
Set swagger-ui docExpansion expansion to "list"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * Add `PhoenixSwagger.SchemaTest` module for response validation
   * Swagger UI plug redirects / to /index.html automatically avoiding errors when fetching assets.
+  * Swagger UI configured to list all operations by default
 
 # 0.6.0
 

--- a/lib/phoenix_swagger/plug/swaggerui.ex
+++ b/lib/phoenix_swagger/plug/swaggerui.ex
@@ -102,7 +102,7 @@ defmodule PhoenixSwagger.Plug.SwaggerUI do
           onFailure: function(data) {
             log("Unable to Load SwaggerUI");
           },
-          docExpansion: "none",
+          docExpansion: "list",
           jsonEditor: false,
           defaultModelRendering: 'schema',
           showRequestHeaders: false,


### PR DESCRIPTION
This causes all the tags to be expanded, listing the available operations.

We could make this configurable, but I think this is a better default and is consistent with the new swaggerui 3.0 layout (http://petstore.swagger.io) 

Resolves #77 

From https://github.com/swagger-api/swagger-ui/tree/2.x#parameters

Parameter Name | Description
-----------------|-------------
docExpansion | Controls how the API listing is displayed. It can be set to 'none' (default), 'list' (shows operations for each resource), or 'full' (fully expanded: shows operations and their details).