### PR TITLE
Default host / port and handle dynamic url config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.6.1
+
+  * Provide default host and port when generating swagger host config
+  * Suppress host config when dynamic hostname or port are used
+
 # 0.6.0
 
   * Use phoenix 1.3 conventions for mix tasks and module names

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ function.
 See the [swaggerObject specification](http://swagger.io/specification/#swaggerObject) for details
 of other information that can be included.
 
+The swagger `host` value is built from the your phoenix `Endpoint` `url` config.
+
+```elixir
+# config.exs
+config :my_app, MyApp.Web.Endpoint,
+  url: [host: "localhost"], # "host": "localhost:4000" in generated swagger
+```
+
+If the `host` is configured to be set dynamically, the swagger host will be omitted. SwaggerUI will default to sending requests to the same host that is serving the swagger file.
+
+```elixir
+# prod.exs
+config :my_app, MyApp.Web.Endpoint,
+  url: [host: {:system, "HOST"}, port: {:system, "PORT"}], # No "host" in generated swagger
+```
 
 ## Swagger Path DSL
 

--- a/examples/simple/config/config.exs
+++ b/examples/simple/config/config.exs
@@ -11,7 +11,7 @@ config :simple,
 
 # Configures the endpoint
 config :simple, Simple.Web.Endpoint,
-  # url: [host: "localhost"],
+  url: [host: "localhost"],
   secret_key_base: "occcf4JQ1yY8UbMxsqJx0+wxhrQFQMvAJi+mYlaWCSJxmmrgGLyt4eZ9oFhrisRP",
   render_errors: [view: Simple.Web.ErrorView, accepts: ~w(json)],
   pubsub: [name: Simple.PubSub,

--- a/examples/simple/config/prod.exs
+++ b/examples/simple/config/prod.exs
@@ -13,11 +13,19 @@ use Mix.Config
 # which you typically run after static files are built.
 config :simple, Simple.Web.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: [host: "example.com", port: 80],
+  url: [host: {:system, "HOST"}, port: {:system, "PORT"}],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 # Do not print debug messages in production
 config :logger, level: :info
+
+config :simple, Simple.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: "postgres",
+  password: "postgres",
+  database: "simple_prod",
+  hostname: "localhost",
+  pool_size: 10
 
 # ## SSL Support
 #
@@ -62,4 +70,4 @@ config :logger, level: :info
 
 # Finally import the config/prod.secret.exs
 # which should be versioned separately.
-import_config "prod.secret.exs"
+# import_config "prod.secret.exs"

--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -184,13 +184,15 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
 
   defp collect_host_from_endpoint(swagger_map, endpoint_config) do
     url = Keyword.get(endpoint_config, :url)
-    host = Keyword.get(url, :host)
-    port = Keyword.get(url, :port)
-    host_address = [host, port]
-      |> Enum.filter(&(!is_nil(&1)))
-      |> Enum.join(":")
+    host = Keyword.get(url, :host, "localhost")
+    port = Keyword.get(url, :port, 4000)
 
-    swagger_map = Map.put_new(swagger_map, :host, host_address)
+    swagger_map =
+      if is_binary(host) and (is_integer(port) or is_binary(port)) do
+        Map.put_new(swagger_map, :host, "#{host}:#{port}")
+      else
+        swagger_map # host / port may be {:system, "ENV_VAR"} tuples
+      end
 
     case endpoint_config[:https] do
       nil ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixSwagger.Mixfile do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.6.1"
 
   def project do
     [app: :phoenix_swagger,


### PR DESCRIPTION
There are two main changes in this PR:

1. `phx.swagger.generate` will use "localhost:4000" for default hostname and port if one is not provided.

2. When host/port are configured to use {:system, "ENV_VAR"} tuples, the swagger host is not included.

This allows a new phoenix project to work with phoenix_swagger without having to change/remove any configuration settings in dev config.

It also allows for deploying swagger-ui to testing environments with dynamic host settings.

Resolves #91 
Resolves #93 