### PR TITLE
fix path to swagger specification file in UI plug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.2
+
+  * fix path assignation of a swagger specification file in UI plug
+
 # 0.6.1
 
   * Provide default host and port when generating swagger host config

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ dependencies in the `mix.exs` file:
 ```elixir
 def deps do
   [
-    {:phoenix_swagger, "~> 0.6.1"},
+    {:phoenix_swagger, "~> 0.6.2"},
     {:ex_json_schema, "~> 0.5"} # optional
   ]
 end

--- a/lib/phoenix_swagger/plug/swaggerui.ex
+++ b/lib/phoenix_swagger/plug/swaggerui.ex
@@ -167,18 +167,18 @@ defmodule PhoenixSwagger.Plug.SwaggerUI do
   """
   def init(otp_app: app, swagger_file: swagger_file) do
     body = EEx.eval_string(@template, spec_url: swagger_file)
-    swagger_file_path = Path.join([Application.app_dir(app), "priv/static", swagger_file])
-    [body: body, spec_url: swagger_file, swagger_file_path: swagger_file_path]
+    swagger_file_path = Path.join(["priv", "static", swagger_file])
+    [app: app, body: body, spec_url: swagger_file, swagger_file_path: swagger_file_path]
   end
 
   @doc """
   Plug.call callback
   """
-  def call(conn, body: body, spec_url: url, swagger_file_path: swagger_file_path) do
+  def call(conn, app: app, body: body, spec_url: url, swagger_file_path: swagger_file_path) do
     conn
     |> Conn.assign(:index_body, body)
     |> Conn.assign(:spec_url, url)
-    |> Conn.assign(:swagger_file_path, swagger_file_path)
+    |> Conn.assign(:swagger_file_path, Path.join([Application.app_dir(app), swagger_file_path]))
     |> super([])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixSwagger.Mixfile do
   use Mix.Project
 
-  @version "0.6.1"
+  @version "0.6.2"
 
   def project do
     [app: :phoenix_swagger,


### PR DESCRIPTION
Path to a swagger specification file is calculated during compilation
based on path of the application directory. Such path can differ from
the same path in runtime.