### PR TITLE
Custom Endpoint Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.3
+
+  * Adds support for custom Endpoint module names by passing `--endpoint`
+
 # 0.6.2
 
   * fix path assignation of a swagger specification file in UI plug

--- a/README.md
+++ b/README.md
@@ -234,7 +234,16 @@ To generate `swagger` file with the custom name/place, pass it to the main mix t
 mix phx.swagger.generate ~/my-phoenix-api.json
 ```
 
-If the project contains multiple `Router` modules, you can generate a swagger file for each one by specifying the router module as an argument to `mix phx.swagger.generate`:
+By default, the project looks for a Router named `(MyApp).Web.Router` and a Endpoint named `(MyApp).Web.Endpoint` consistent with Phoenix 1.3
+conventions. If your project does not yet follow that convention, or if you wish to generate a Swagger File with a custom Endpoint, you can
+specify the endpoint module as an argument (`-e` or `--endpoint`) to `mix phx.swagger.generate`:
+
+```
+mix phx.swagger.generate endpoint.json -e MyApp.Endpoint
+```
+
+If the project contains multiple `Router` modules, you can generate a swagger file for each one by specifying the router module as an argument
+(`-r` or `--router`) to `mix phx.swagger.generate`:
 
 ```
 mix phx.swagger.generate booking-api.json -r MyApp.BookingRouter

--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
   defp default_swagger_file_path, do: app_path() <> "swagger.json"
   defp default_router_module_name, do: Module.concat([top_level_namespace(), :Web, :Router])
   defp default_endpoint_module_name, do: Module.concat([top_level_namespace(), :Web, :Endpoint])
-  defp router_module(switches), do: switches |> Keyword.get(:router, default_endpoint_module_name()) |> attempt_load()
+  defp router_module(switches), do: switches |> Keyword.get(:router, default_router_module_name()) |> attempt_load()
   defp endpoint_module(switches), do: switches |> Keyword.get(:endpoint, default_endpoint_module_name()) |> attempt_load()
   
   def run(args) do

--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -1,6 +1,7 @@
 defmodule Mix.Tasks.Phx.Swagger.Generate do
   use Mix.Task
-
+  require Logger
+  
   @recursive true
 
   @shortdoc "Generates swagger.json file based on phoenix router"
@@ -134,16 +135,18 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
   defp find_swagger_path_function(route = %{opts: action, path: path}) when is_atom(action) do
     controller = find_controller(route)
     swagger_fun = "swagger_path_#{action}" |> String.to_atom()
-
-    unless Code.ensure_loaded?(controller) do
-      raise "Error: #{controller} module didn't load."
+    
+    cond do
+      Code.ensure_loaded?(controller) ->
+        %{
+          controller: controller,
+          swagger_fun: swagger_fun,
+          path: format_path(path)
+        }
+      true ->
+        Logger.warn "Warning: #{controller} module didn't load."
+        nil
     end
-
-    %{
-      controller: controller,
-      swagger_fun: swagger_fun,
-      path: format_path(path)
-    }
   end
   defp find_swagger_path_function(_route) do
     # action not an atom usually means route to a plug which isn't a Phoenix controller

--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -38,8 +38,8 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
     Code.append_path("#{app_path()}_build/#{Mix.env}/lib/#{app_name()}/ebin")
     {switches, params, _unknown} = OptionParser.parse(
       args,
-      switches: [router: :string, help: :boolean],
-      aliases: [r: :router, h: :help])
+      switches: [router: :string, endpoint: :string, help: :boolean],
+      aliases: [r: :router, e: :endpoint, h: :help])
     
     router = router_module(switches)
     endpoint = endpoint_module(switches)

--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -29,8 +29,8 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
   defp default_swagger_file_path, do: app_path() <> "swagger.json"
   defp default_router_module_name, do: Module.concat([top_level_namespace(), :Web, :Router])
   defp default_endpoint_module_name, do: Module.concat([top_level_namespace(), :Web, :Endpoint])
-  defp router_module(switches), do: switches |> Keyword.get(:router, default_endpoint_module_name()) |> attempt_load
-  defp endpoint_module(switches), do: switches |> Keyword.get(:endpoint, default_endpoint_module_name()) |> attempt_load
+  defp router_module(switches), do: switches |> Keyword.get(:router, default_endpoint_module_name()) |> attempt_load()
+  defp endpoint_module(switches), do: switches |> Keyword.get(:endpoint, default_endpoint_module_name()) |> attempt_load()
   
   def run(args) do
     Mix.Task.run("compile")
@@ -47,9 +47,9 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
       (Keyword.get(switches, :help)) ->
         usage()
       is_nil(router) ->
-        Logger.error "Skipping app #{app_name()}, no Router configured."
+        Logger.warn "Skipping app #{app_name()}, no Router configured."
       is_nil(endpoint) ->
-        Logger.error "Skipping app #{app_name()}, no Endpoint configured."
+        Logger.warn "Skipping app #{app_name()}, no Endpoint configured."
       true ->
         output_file = Enum.at(params, 0, default_swagger_file_path())
         write_file(output_file, swagger_document(router, endpoint))
@@ -77,7 +77,7 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
   end
   
   defp attempt_load(module_name) do
-    case module_name |> List.wrap |> Module.concat |> Code.ensure_loaded do
+    case module_name |> List.wrap() |> Module.concat() |> Code.ensure_loaded() do
       {:module, result} -> result
       _ -> nil
     end


### PR DESCRIPTION
I have an app which uses Phoenix 1.3 without having fully adopted its conventions. This means that its Endpoint does not have a `Web` prefix and so Phoenix Swagger does not work right away.

I have made a couple changes essentially allowing the module name for Endpoint to be passed in from the Mix task, when regenerating a Swagger document.

In addition there is another small fix for when not all modules can be reached when enumerating routes from within a Router. I have found that when prototyping a system it is beneficial to have all the routes laid out first before implementing the controllers. It is still beneficial to have Swagger documents generated from time to time without the routes being fully implemented.