### PR TITLE
SwaggerUI plug options combined into single list

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Add a swagger scope to your router, and forward all requests to SwaggerUI
 
 ```elixir
     scope "/api/swagger" do
-      forward "/", PhoenixSwagger.Plug.SwaggerUI, otp_app: :myapp, swagger_file: "swagger.json", opts: [disable_validator: true]
+      forward "/", PhoenixSwagger.Plug.SwaggerUI, otp_app: :myapp, swagger_file: "swagger.json", disable_validator: true
     end
 ```
 

--- a/lib/phoenix_swagger/plug/swaggerui.ex
+++ b/lib/phoenix_swagger/plug/swaggerui.ex
@@ -165,8 +165,17 @@ defmodule PhoenixSwagger.Plug.SwaggerUI do
 
   @doc """
   Plug.init callback
+
+  Options:
+
+   - `otp_app` (required) The name of the app has is hosting the swagger file
+   - `swagger_file` (required) The name of the file, eg "swagger.json"
+   - `disable_validator` (optional) When set to true, disables swagger schema validation
+
   """
-  def init(otp_app: app, swagger_file: swagger_file, opts: opts) do
+  def init(opts) do
+    app = Keyword.fetch!(opts, :otp_app)
+    swagger_file = Keyword.fetch!(opts, :swagger_file)
     disable_validator = Keyword.get(opts, :disable_validator, false)
     validator_url = cond do
       disable_validator == true ->


### PR DESCRIPTION
No longer requires passing the empty `opts: []` list when not overriding
the `disable_validator` flag.