### PR TITLE
fix small example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ defmodule MyApp.Router do
 
   scope "/api", MyApp do
     pipe_through :api
-    resources "/users", UserController
+    resource "/users", UserController
   end
 
   def swagger_info do


### PR DESCRIPTION
Super-basic example in readme.md has `resources` instead of `resource`. There is no `resources` function in PhoenixSwagger module. 