### PR TITLE
Add Validator plug to example project

### DIFF
--- a/examples/simple/lib/simple/application.ex
+++ b/examples/simple/lib/simple/application.ex
@@ -1,10 +1,12 @@
 defmodule Simple.Application do
   use Application
+  import Supervisor.Spec, only: [supervisor: 2]
 
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
-    import Supervisor.Spec
+
+    PhoenixSwagger.Validator.parse_swagger_schema("priv/static/swagger.json")
 
     # Define workers and child supervisors to be supervised
     children = [

--- a/examples/simple/lib/simple/web/router.ex
+++ b/examples/simple/lib/simple/web/router.ex
@@ -1,8 +1,10 @@
 defmodule Simple.Web.Router do
   use Simple.Web, :router
+  alias PhoenixSwagger.Plug.Validate
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug Validate, validation_failed_status: 422
   end
 
   scope "/api", Simple.Web do

--- a/examples/simple/mix.exs
+++ b/examples/simple/mix.exs
@@ -18,7 +18,7 @@ defmodule Simple.Mixfile do
   # Type `mix help compile.app` for more information.
   def application do
     [mod: {Simple.Application, []},
-     applications: [:phoenix, :phoenix_pubsub, :cowboy, :logger, :gettext,
+     applications: [:phoenix, :phoenix_pubsub, :phoenix_swagger, :cowboy, :logger, :gettext,
                     :phoenix_ecto, :postgrex]]
   end
 

--- a/examples/simple/test/controllers/user_controller_test.exs
+++ b/examples/simple/test/controllers/user_controller_test.exs
@@ -49,7 +49,10 @@ defmodule Simple.UserControllerTest do
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do
     conn = post conn, user_path(conn, :create), user: @invalid_attrs
-    assert json_response(conn, 422)["errors"] != %{}
+    assert json_response(conn, 422)["error"] == %{
+      "message" => "Required property email was not present.",
+      "path" => "#/user"
+    }
   end
 
   test "updates and renders chosen resource when data is valid", %{conn: conn, swagger_schema: schema} do
@@ -67,7 +70,18 @@ defmodule Simple.UserControllerTest do
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     user = Repo.insert! %User{}
     conn = put conn, user_path(conn, :update, user), user: @invalid_attrs
-    assert json_response(conn, 422)["errors"] != %{}
+    assert json_response(conn, 422)["error"] == %{
+      "message" => "Required property email was not present.",
+      "path" => "#/user"
+    }
+  end
+
+  test "UserID path param must be an integer", %{conn: conn} do
+    conn = put conn, user_path(conn, :update, "abc"), user: @valid_attrs
+    assert json_response(conn, 422)["error"] == %{
+      "message" => "Type mismatch. Expected Integer but got String.",
+      "path" => "#/id"
+    }
   end
 
   test "deletes chosen resource", %{conn: conn} do

--- a/lib/phoenix_swagger/plug/validate_plug.ex
+++ b/lib/phoenix_swagger/plug/validate_plug.ex
@@ -92,13 +92,12 @@ defmodule PhoenixSwagger.Plug.Validate do
     validate_boolean(name, val, parameters)
   end
   defp validate_query_params(path, conn) do
-    params = Map.merge(conn.query_params, conn.path_params)
     [{_path, _basePath, schema}] = :ets.lookup(@table, path)
     parameters =
       for parameter <- schema.schema["parameters"],
           parameter["type"] != nil,
           parameter["in"] in ["query", "path"] do
-        {parameter["type"], parameter["name"], params[parameter["name"]], parameter["required"]}
+        {parameter["type"], parameter["name"], conn.params[parameter["name"]], parameter["required"]}
       end
     validate_query_params(parameters)
   end

--- a/lib/phoenix_swagger/plug/validate_plug.ex
+++ b/lib/phoenix_swagger/plug/validate_plug.ex
@@ -35,10 +35,16 @@ defmodule PhoenixSwagger.Plug.Validate do
           conn
         else
           {:error, error, path} ->
-            error = get_error_message(error)
-            response = %{"error" => %{"message" => error,
-                                      "path" => path}} |> Poison.encode!
-            send_resp(conn, validation_failed_status, response)
+            response = Poison.encode! %{
+              error: %{
+                message: get_error_message(error),
+                path: path
+              }
+            }
+
+            conn
+            |> put_resp_content_type("application/json")
+            |> send_resp(validation_failed_status, response)
             |> halt()
         end
     end

--- a/lib/phoenix_swagger/plug/validate_plug.ex
+++ b/lib/phoenix_swagger/plug/validate_plug.ex
@@ -58,17 +58,11 @@ defmodule PhoenixSwagger.Plug.Validate do
     |> halt()
   end
 
-  defp validate_boolean(name, value, parameters) do
-    try do
-      val = String.to_existing_atom(value)
-      if val != true and val != false do
-        {:error, "Type mismatch. Expected Boolean but got String.", "#/#{name}"}
-      else
-        validate_query_params(parameters)
-      end
-    rescue _e in ArgumentError ->
-        {:error, "Type mismatch. Expected Boolean but got String.", "#/#{name}"}
-    end
+  defp validate_boolean(_name, value, parameters) when value in ["true", "false"] do
+    validate_query_params(parameters)
+  end
+  defp validate_boolean(name, _value, _parameters) do
+    {:error, "Type mismatch. Expected Boolean but got String.", "#/#{name}"}
   end
 
   defp validate_integer(name, value, parameters) do

--- a/lib/phoenix_swagger/plug/validate_plug.ex
+++ b/lib/phoenix_swagger/plug/validate_plug.ex
@@ -116,16 +116,10 @@ defmodule PhoenixSwagger.Plug.Validate do
     end
   end
 
-  defp equal_paths(_, [], req) when length(req) > 0, do: []
-  defp equal_paths(_, orig, []) when length(orig) > 0, do: []
-  defp equal_paths(orig_path, [], []), do: orig_path
-  defp equal_paths(orig_path, [orig | orig_path_rest], [ req | req_path_rest]) do
-    if (String.codepoints(orig) |> hd) == "{" or orig == req do
-      equal_paths(orig_path, orig_path_rest, req_path_rest)
-    else
-      []
-    end
-  end
+  defp equal_paths?([], []), do: true
+  defp equal_paths?([head | orig_path_rest], [head | req_path_rest]), do: equal_paths?(orig_path_rest, req_path_rest)
+  defp equal_paths?(["{" <> _ | orig_path_rest], [_ | req_path_rest]), do: equal_paths?(orig_path_rest, req_path_rest)
+  defp equal_paths?(_, _), do: false
 
   # It is pretty safe to strip request path by base path. They can't be
   # non-equal. In this way, the router even will not execute this plug.

--- a/lib/phoenix_swagger/plug/validate_plug.ex
+++ b/lib/phoenix_swagger/plug/validate_plug.ex
@@ -133,7 +133,4 @@ defmodule PhoenixSwagger.Plug.Validate do
   defp remove_base_path([_path | rest], [_base_path | base_path_rest]) do
     remove_base_path(rest, base_path_rest)
   end
-
-  defp get_error_message(error) when is_list(error), do: List.first(error) |> elem(0)
-  defp get_error_message(error), do: error
 end

--- a/lib/phoenix_swagger/plug/validate_plug.ex
+++ b/lib/phoenix_swagger/plug/validate_plug.ex
@@ -17,9 +17,7 @@ defmodule PhoenixSwagger.Plug.Validate do
     validation_failed_status = Keyword.get(opts, :validation_failed_status, 400)
     req_path = Enum.filter(:ets.tab2list(@table), fn({path, basePath, _}) ->
       pathInfo = remove_base_path(conn.path_info, String.split(basePath, "/") |> tl)
-      req_path = ("/" <> String.downcase(conn.method) <> "/" <> Enum.join(pathInfo, "/"))
-                 |> String.split("/")
-                 |> tl
+      req_path = [String.downcase(conn.method) | pathInfo]
       equal_paths(path, String.split(path, "/") |> tl, req_path) != []
     end)
     with [{path, _, _}] <- req_path,

--- a/lib/phoenix_swagger/plug/validate_plug.ex
+++ b/lib/phoenix_swagger/plug/validate_plug.ex
@@ -66,12 +66,10 @@ defmodule PhoenixSwagger.Plug.Validate do
   end
 
   defp validate_integer(name, value, parameters) do
-    try do
-      _ = String.to_integer(value)
-      validate_query_params(parameters)
-    rescue _e in ArgumentError ->
-        {:error, "Type mismatch. Expected Integer but got String.", "#/#{name}"}
-    end
+    _ = String.to_integer(value)
+    validate_query_params(parameters)
+  rescue ArgumentError ->
+      {:error, "Type mismatch. Expected Integer but got String.", "#/#{name}"}
   end
 
   defp validate_query_params([]), do: :ok

--- a/lib/phoenix_swagger/plug/validate_plug.ex
+++ b/lib/phoenix_swagger/plug/validate_plug.ex
@@ -30,17 +30,11 @@ defmodule PhoenixSwagger.Plug.Validate do
         send_resp(conn, 404, response)
         |> halt()
       [{path, _, _}] ->
-        case {validate_body_params(path, conn.params),
-              validate_query_params(path, conn.params)} do
-          {:ok, :ok} ->
-            conn
-          {{:error, error, path}, _} ->
-            error = get_error_message(error)
-            response = %{"error" => %{"message" => error,
-                                      "path" => path}} |> Poison.encode!
-            send_resp(conn, validation_failed_status, response)
-            |> halt()
-          {_, {:error, error, path}} ->
+        with :ok <- validate_body_params(path, conn.params),
+             :ok <- validate_query_params(path, conn.params) do
+          conn
+        else
+          {:error, error, path} ->
             error = get_error_message(error)
             response = %{"error" => %{"message" => error,
                                       "path" => path}} |> Poison.encode!

--- a/lib/phoenix_swagger/validator.ex
+++ b/lib/phoenix_swagger/validator.ex
@@ -104,7 +104,7 @@ defmodule PhoenixSwagger.Validator do
         if parameters == nil do
           []
         else
-          # Let's go through requests parameters from swagger scheme
+          # Let's go through requests parameters from swagger schema
           # and collect it into json schema properties.
           properties = Enum.reduce(parameters, %{}, fn(parameter, acc) ->
             acc = if parameter["type"] == nil do


### PR DESCRIPTION
This PR started by trying to add the Validator plug to the example app.
Along the way I needed to add a couple of features, and took the opportunity to refactor the code a bit. I've tried to break it up to allow reviewing each commit separately.

## Changes Summary

- `examples/simple/lib/web/router` adds `PhoenixSwagger.Plug.Validate` to the `api` pipeline
- `PhoenixSwagger.Plug.Validate` accepts a `:validation_failed_status` option, defaults to 400 but can be used to produce 422 responses when validation fails
- `PhoenixSwagger.Plug.Validate` works when `basePath` is missing from swagger spec. Was previously throwing an `ArgumentError` trying to `String.split` the `basePath`.
- Error responses from `PhoenixSwagger.Plug.Validate` plug set the response content type to `application/json`. Without this the `json_response` test helpers didn't work.
- `PhoenixSwagger.Plug.Validate` validates `path` params with `query` params instead of passing `path` params through with `body` params. This would cause an `integer` path param to fail validation.

