### PR TITLE
Allow poison 3.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule PhoenixSwagger.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-        {:poison, "~> 1.5 or ~> 2.0"},
+        {:poison, "~> 1.5 or ~> 2.0 or ~> 3.1"},
         {:ex_json_schema, "~> 0.5.1", optional: :true},
         {:plug, "~> 1.1"},
         {:ex_doc, "~> 0.14", only: :dev, runtime: false}

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule PhoenixSwagger.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-        {:poison, "~> 1.5 or ~> 2.0 or ~> 3.1"},
+        {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0 or ~> 3.1"},
         {:ex_json_schema, "~> 0.5.1", optional: :true},
         {:plug, "~> 1.1"},
         {:ex_doc, "~> 0.14", only: :dev, runtime: false}

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule PhoenixSwagger.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-        {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0 or ~> 3.1"},
+        {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
         {:ex_json_schema, "~> 0.5.1", optional: :true},
         {:plug, "~> 1.1"},
         {:ex_doc, "~> 0.14", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "ex_json_schema": {:hex, :ex_json_schema, "0.5.5", "d8d4c3f47b86c9e634e124d518b290dda82a8b94dcc314e45af10042fc369361", [:mix], []},
-  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
-  "plug": {:hex, :plug, "1.3.0", "6e2b01afc5db3fd011ca4a16efd9cb424528c157c30a44a0186bcc92c7b2e8f3", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}
+%{"earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_json_schema": {:hex, :ex_json_schema, "0.5.5", "d8d4c3f47b86c9e634e124d518b290dda82a8b94dcc314e45af10042fc369361", [:mix], [], "hexpm"},
+  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.3.0", "6e2b01afc5db3fd011ca4a16efd9cb424528c157c30a44a0186bcc92c7b2e8f3", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"}}


### PR DESCRIPTION
The version of poison in this project is far behind the latest version. Due to some other dependencies I need phoenix_swagger to support poison 3.1 as well. 