### PR TITLE
Implement Phoenix 1.3 Namespacing Recognition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.6.5
+
+  * Minor fix that supports the Phoenix 1.3 namespacing, where it is {Project}Web instead
+    of {Project}.Web.
+  * A switch, --use_1_2_namespacing (or -n for short), was added to support legacy (Phoenix < 1.3) namespacing.
+
 # 0.6.4
 
   * Adds support to enable security by endpoint

--- a/README.md
+++ b/README.md
@@ -255,6 +255,12 @@ mix phx.swagger.generate reports-api.json -r MyApp.ReportsRouter
 mix phx.swagger.generate admin-api.json -r MyApp.AdminRouter
 ```
 
+For Phoenix 1.2 or lower, use the --use_1_2_namespacing, or -n, to generate the `swagger.json` file:
+
+```
+mix phx.swagger.generate -n
+```
+
 For more informantion, you can find `swagger` specification [here](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md).
 
 ## Validator

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixSwagger.Mixfile do
   use Mix.Project
 
-  @version "0.6.4"
+  @version "0.6.5"
 
   def project do
     [app: :phoenix_swagger,


### PR DESCRIPTION
* Phoenix 1.3 namespaces now supported with phx.swagger.generate.
* phx.swagger.generate now has --use_1_2_namespacing flag for
  Phoenix 1.2 applications.
* Version bump to 0.6.5.

Between Phoenix 1.3 RCs and the Phoenix 1.3 release, a
modification was made to the Web namespace: instead of
the namespace being {ProjectName}.Web, it was changed to
{ProjectName}Web. The namespace for the router and endpoint
now correctly defaults to the correct 1.3 namespace, and
a switch has been added to support generating Swagger json
files in 1.2 applications.