### PR TITLE
Implement Phoenix 1.3 Namespacing Recognition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.6.5
+# 0.7.0
 
   * Minor fix that supports the Phoenix 1.3 namespacing, where it is {Project}Web instead of {Project}.Web.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.5
+
+  * Minor fix that supports the Phoenix 1.3 namespacing, where it is {Project}Web instead of {Project}.Web.
+
 # 0.6.4
 
   * Adds support to enable security by endpoint

--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -27,11 +27,11 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
   defp top_level_namespace, do: Mix.Project.get().application()[:mod] |> elem(0) |> Module.split |> Enum.drop(-1) |> Module.concat
   defp app_name, do: Mix.Project.get().project()[:app]
   defp default_swagger_file_path, do: app_path() <> "swagger.json"
-  defp default_router_module_name, do: Module.concat([top_level_namespace(), :Web, :Router])
-  defp default_endpoint_module_name, do: Module.concat([top_level_namespace(), :Web, :Endpoint])
+  defp default_router_module_name, do: Module.concat(["#{top_level_namespace()}Web", :Router])
+  defp default_endpoint_module_name, do: Module.concat(["#{top_level_namespace()}Web", :Endpoint])
   defp router_module(switches), do: switches |> Keyword.get(:router, default_router_module_name()) |> attempt_load()
   defp endpoint_module(switches), do: switches |> Keyword.get(:endpoint, default_endpoint_module_name()) |> attempt_load()
-  
+
   def run(args) do
     Mix.Task.run("compile")
     Mix.Task.reenable("phx.swagger.generate")
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
       args,
       switches: [router: :string, endpoint: :string, help: :boolean],
       aliases: [r: :router, e: :endpoint, h: :help])
-    
+
     router = router_module(switches)
     endpoint = endpoint_module(switches)
     cond do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixSwagger.Mixfile do
   use Mix.Project
 
-  @version "0.6.5"
+  @version "0.7.0"
 
   def project do
     [app: :phoenix_swagger,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixSwagger.Mixfile do
   use Mix.Project
 
-  @version "0.6.4"
+  @version "0.6.5"
 
   def project do
     [app: :phoenix_swagger,


### PR DESCRIPTION
* Phoenix 1.3 namespaces now supported with phx.swagger.generate.
* Version bump to 0.6.5.
* Fixes Issue 117.

Between Phoenix 1.3 RCs and the Phoenix 1.3 release, a
modification was made to the Web namespace: instead of
the namespace being {ProjectName}.Web, it was changed to
{ProjectName}Web. The namespace for the router and endpoint
now correctly defaults to the correct 1.3 namespace.

Phoenix 1.2 applications are still supported by providing the
router and endpoint to phx.swagger.generate using the -r and -e
switches.