### PR TITLE
Allow relationships to be array

### DIFF
--- a/lib/phoenix_swagger/json_api.ex
+++ b/lib/phoenix_swagger/json_api.ex
@@ -259,7 +259,7 @@ defmodule PhoenixSwagger.JsonApi do
     )
   end
 
-  def relationship_data(:has_one, name) do
+  defp relationship_data(:has_one, name) do
     %Schema{
       type: :object,
       properties: %{
@@ -268,7 +268,7 @@ defmodule PhoenixSwagger.JsonApi do
       }
     }
   end
-  def relationship_data(:has_many, name) do
+  defp relationship_data(:has_many, name) do
     %Schema{
       type: :array,
       items: %Schema{

--- a/lib/phoenix_swagger/json_api.ex
+++ b/lib/phoenix_swagger/json_api.ex
@@ -235,7 +235,8 @@ defmodule PhoenixSwagger.JsonApi do
   @doc """
   Defines a relationship
   """
-  def relationship(model = %Schema{}, name) do
+  def relationship(model = %Schema{}, name, opts \\ []) do
+
     put_in(
       model.properties.relationships.properties[name],
       %Schema{
@@ -249,7 +250,7 @@ defmodule PhoenixSwagger.JsonApi do
             }
           },
           data: %Schema{
-            type: :object,
+            type: opts[:type] || :object,
             properties: %{
               id: %Schema{type: :string, description: "Related #{name} resource id"},
               type: %Schema{type: :string, description: "Type of related #{name} resource"}

--- a/lib/phoenix_swagger/json_api.ex
+++ b/lib/phoenix_swagger/json_api.ex
@@ -234,8 +234,12 @@ defmodule PhoenixSwagger.JsonApi do
 
   @doc """
   Defines a relationship
+  Optionally can pass `type: :has_many` or `type: :has_one` to determine
+  whether to structure the relationship as an object or array.
+  Defaults to `:has_one`
   """
   def relationship(model = %Schema{}, name, opts \\ []) do
+    type = opts[:type] || :has_one
 
     put_in(
       model.properties.relationships.properties[name],
@@ -249,15 +253,31 @@ defmodule PhoenixSwagger.JsonApi do
               related: %Schema{type: :string, description: "Related #{name} link"}
             }
           },
-          data: %Schema{
-            type: opts[:type] || :object,
-            properties: %{
-              id: %Schema{type: :string, description: "Related #{name} resource id"},
-              type: %Schema{type: :string, description: "Type of related #{name} resource"}
-            }
-          }
+          data: relationship_data(type, name)
         }
       }
     )
+  end
+
+  def relationship_data(:has_one, name) do
+    %Schema{
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, description: "Related #{name} resource id"},
+        type: %Schema{type: :string, description: "Type of related #{name} resource"}
+      }
+    }
+  end
+  def relationship_data(:has_many, name) do
+    %Schema{
+      type: :array,
+      items: %Schema{
+        type: :object,
+        properties: %{
+          id: %Schema{type: :string, description: "Related #{name} resource id"},
+          type: %Schema{type: :string, description: "Type of related #{name} resource"}
+        }
+      }
+    }
   end
 end

--- a/test/json_api_test.exs
+++ b/test/json_api_test.exs
@@ -147,4 +147,25 @@ defmodule PhoenixSwagger.JsonApiTest do
       }
     }
   end
+
+  test "relationship can be an array of resources" do
+    user_resource_schema =
+      JsonApi.resource do
+        description "A user that may have one or more supporter pages."
+        attributes do
+          phone :string, "Users phone number"
+          full_name :string, "Full name"
+          user_updated_at :string, "Last update timestamp UTC", format: "ISO-8601"
+          user_created_at :string, "First created timestamp UTC"
+          email :string, "Email", required: true
+          birthday :string, "Birthday in YYYY-MM-DD format"
+          address Schema.ref(:Address), "Users address"
+          gender [:string, "null"], "Gender"
+        end
+        link :self, "The link to this user resource"
+        relationship :posts, type: :array
+      end
+
+    assert user_resource_schema["properties"]["relationships"]["properties"]["posts"]["properties"]["data"]["type"] == "array"
+  end
 end

--- a/test/json_api_test.exs
+++ b/test/json_api_test.exs
@@ -163,7 +163,7 @@ defmodule PhoenixSwagger.JsonApiTest do
           gender [:string, "null"], "Gender"
         end
         link :self, "The link to this user resource"
-        relationship :posts, type: :array
+        relationship :posts, type: :has_many
       end
 
     assert user_resource_schema["properties"]["relationships"]["properties"]["posts"]["properties"]["data"]["type"] == "array"


### PR DESCRIPTION
JSON API allows relationships to be arrays for "has-many". This patch allows a `:type` option to be passed to the `relationship` function so that the relationship can be set to `:array` (currently it's hardcoded to `:object`).