### PR TITLE
Remove "null" from type of JSONAPI prev/next

### DIFF
--- a/lib/phoenix_swagger/json_api.ex
+++ b/lib/phoenix_swagger/json_api.ex
@@ -66,11 +66,11 @@ defmodule PhoenixSwagger.JsonApi do
               description:  "Link to this page of results"
             },
             prev: %Schema {
-              type:  [:string, "null"],
+              type:  :string,
               description:  "Link to the previous page of results"
             },
             next: %Schema {
-              type:  [:string, "null"],
+              type:  :string,
               description:  "Link to the next page of results"
             },
             last: %Schema {
@@ -186,7 +186,7 @@ defmodule PhoenixSwagger.JsonApi do
       [do: {:__block__, _, attrs}] -> attrs
       [do: attr] -> [attr]
     end
-    
+
     attrs
     |> Enum.map(fn {name, line, args} -> {:attribute, line, [name | args]} end)
     |> Enum.reduce(model, fn next, pipeline ->

--- a/test/json_api_test.exs
+++ b/test/json_api_test.exs
@@ -41,8 +41,8 @@ defmodule PhoenixSwagger.JsonApiTest do
           "properties" => %{
             "first" => %{"description" => "Link to the first page of results", "type" => "string"},
             "last" => %{"description" => "Link to the last page of results", "type" => "string"},
-            "next" => %{"description" => "Link to the next page of results", "type" => ["string", "null"]},
-            "prev" => %{"description" => "Link to the previous page of results", "type" => ["string", "null"]},
+            "next" => %{"description" => "Link to the next page of results", "type" => "string"},
+            "prev" => %{"description" => "Link to the previous page of results", "type" => "string"},
             "self" => %{"description" => "Link to this page of results", "type" => "string"}
           },
           "type" => "object"


### PR DESCRIPTION
Fixes #133

# Test Report
## Before
![screen shot 2017-10-31 at 2 05 14 pm](https://user-images.githubusercontent.com/298259/32244059-5e759784-be45-11e7-9ad1-ac49eb2ec161.png)

## After
![screen shot 2017-10-31 at 2 10 04 pm](https://user-images.githubusercontent.com/298259/32244076-641fde7e-be45-11e7-828e-1bf7c69dd25f.png)

# Changelog
## Bug Fixes
* Remove "null" from type of JSONAPI prev/next because SwaggerUI does not understand that type.