### PR TITLE
correct arguments of parameter function in docs

### DIFF
--- a/docs/reusing-swagger-parameters.md
+++ b/docs/reusing-swagger-parameters.md
@@ -45,7 +45,7 @@ defmodule CommonParameters do
   import PhoenixSwagger.Path
 
   def authorization(path = %PathObject{}) do
-    path |> parameter("Authorization", :header, "OAuth2 access token", required: true)
+    path |> parameter("Authorization", :header, :string, "OAuth2 access token", required: true)
   end
 
   def sorting(path = %PathObject{}) do


### PR DESCRIPTION
parameter function takes 4th arguments which describe type of the parameter.