### PR TITLE
Use explicit configuration for swagger file generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.8.0
+
+  * Passing module names and output path as mix task parameters is no longer supported.
+  * Inferring default module names from mix project is no longer supported.
+  * Swagger file outputs, router module and optional endpoint module must now be specified in application config:
+
+  ```elixir
+  config :my_app, :phoenix_swagger,
+    swagger_files: %{
+      "priv/static/swagger.json" => [router: MyAppWeb.Router, endpoint: MyAppWeb.Endpoint],
+      # additional swagger files here
+    }
+  ```
+
 # 0.7.1
 
   * Use the :load_from_system_env Endpoint config flag to detect dynamic host and port configuration

--- a/README.md
+++ b/README.md
@@ -20,18 +20,29 @@ dependencies in the `mix.exs` file:
 ```elixir
 def deps do
   [
-    {:phoenix_swagger, "~> 0.7.0"},
+    {:phoenix_swagger, "~> 0.8"},
     {:ex_json_schema, "~> 0.5"} # optional
   ]
 end
 ```
 
-For Phoenix 1.2 or lower, please use version `"~> 0.5.0"`.
 `ex_json_schema` is an optional dependency of `phoenix_swagger` required only for schema validation plug and test helper.
 
 Now you can use `phoenix_swagger` to generate `swagger-ui` file for you application.
 
 ## Usage
+
+Add a config entry to your phoenix application specifying the output filename, router and endpoint modules used to generate the swagger file:
+
+```elixir
+config :my_app, :phoenix_swagger,
+  swagger_files: %{
+    "priv/static/swagger.json" => [
+      router: MyAppWeb.Router,     # phoenix routes will be converted to swagger paths
+      endpoint: MyAppWeb.Endpoint  # (optional) endpoint config used to set host, port and https schemes.
+    ]
+  }
+```
 
 The outline of the swagger document should be returned from a `swagger_info/0` function
 defined in your phoenix `Router.ex` module.
@@ -239,28 +250,15 @@ mix task for the `swagger-ui` json file generation into directory with `phoenix`
 mix phx.swagger.generate
 ```
 
-As the result there will be `swagger.json` file into root directory of the `phoenix` application.
-To generate `swagger` file with the custom name/place, pass it to the main mix task:
+If multiple swagger files need to be generated, add additional entries to the project config:
 
-```
-mix phx.swagger.generate ~/my-phoenix-api.json
-```
-
-By default, the project looks for a Router named `(MyApp).Web.Router` and a Endpoint named `(MyApp).Web.Endpoint` consistent with Phoenix 1.3
-conventions. If your project does not yet follow that convention, or if you wish to generate a Swagger File with a custom Endpoint, you can
-specify the endpoint module as an argument (`-e` or `--endpoint`) to `mix phx.swagger.generate`:
-
-```
-mix phx.swagger.generate endpoint.json -e MyApp.Endpoint
-```
-
-If the project contains multiple `Router` modules, you can generate a swagger file for each one by specifying the router module as an argument
-(`-r` or `--router`) to `mix phx.swagger.generate`:
-
-```
-mix phx.swagger.generate booking-api.json -r MyApp.BookingRouter
-mix phx.swagger.generate reports-api.json -r MyApp.ReportsRouter
-mix phx.swagger.generate admin-api.json -r MyApp.AdminRouter
+```elixir
+config :my_app, :phoenix_swagger,
+  swagger_files: %{
+    "booking-api.json" => [router: MyApp.BookingRouter],
+    "reports-api.json" => [router: MyApp.ReportsRouter],
+    "admin-api.json" => [router: MyApp.AdminRouter]
+  }
 ```
 
 For more informantion, you can find `swagger` specification [here](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md).
@@ -365,17 +363,24 @@ PhoenixSwagger includes a plug with all static assets required to host swagger-u
 
 Usage:
 
-Generate a swagger file and place it in your applications `priv/static` dir:
+Generate a swagger file in your applications `priv/static` dir:
 
 ```
-mix phx.swagger.generate priv/static/myapp.json
+config :my_app, :phoenix_swagger,
+  swagger_files: %{
+    "priv/static/swagger.json" => [router: MyAppWeb.Router]
+  }
+```
+
+```
+mix phx.swagger.generate
 ```
 
 Add a swagger scope to your router, and forward all requests to SwaggerUI
 
 ```elixir
     scope "/api/swagger" do
-      forward "/", PhoenixSwagger.Plug.SwaggerUI, otp_app: :myapp, swagger_file: "swagger.json", disable_validator: true
+      forward "/", PhoenixSwagger.Plug.SwaggerUI, otp_app: :myapp, swagger_file: "swagger.json"
     end
 ```
 

--- a/examples/simple/config/config.exs
+++ b/examples/simple/config/config.exs
@@ -9,6 +9,11 @@ use Mix.Config
 config :simple,
   ecto_repos: [Simple.Repo]
 
+config :simple, :phoenix_swagger,
+  swagger_files: %{
+    "priv/static/swagger.json" => [router: SimpleWeb.Router]
+  }
+
 # Configures the endpoint
 config :simple, SimpleWeb.Endpoint,
   url: [host: "localhost"],

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixSwagger.Mixfile do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.8.0"
 
   def project do
     [app: :phoenix_swagger,


### PR DESCRIPTION
Following from #130, this change should allow `mix phx.swagger.generate` to run from anywhere in an umbrella project and output the swagger file/s as expected.

### Summary of changes 

Remove command line options and default values for specifying `Router` and `Endpoint`.
Each project that generates swagger files must declare a configuration such as:

```elixir
config :my_project, :phoenix_swagger,
  swagger_files: %{
    "priv/static/swagger.json" => [router: Some.Router, endpoint: Some.Endpoint]
  }
```

`:endpoint` is optional in the configuration.

Multiple swagger files can be created, supporting the scenarios when a single project contains multiple `Router` modules or even multiple `Endpoint` listening on different ports.

### Questions

 - Is there a cleaner way to express the configuration that still handles the multiple routers/endpoints use cases?
 -  Should we keep the explicit command line args, perhaps deprecated?
 - Should we keep the convention based defaults, perhaps deprecated?

/cc: @angelikatyborska, @jueberschlag