### PR TITLE
Allow verb and path to be inferred from router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@
     }
   ```
 
+  * The HTTP verb and path can now be inferred from the phoenix router:
+
+  ```elixir
+  swagger_path :show do
+    get "/api/users/{id}
+    description "Gets a user by ID"
+    response 200, "OK", Schema.ref(User)
+  end
+  ```
+  Can now be written without the `get`:
+  ```elixir
+  swagger_path :show do
+    description "Gets a user by ID"
+    response 200, "OK", Schema.ref(User)
+  end
+  ```
+  Note that if your controller contains a `delete/2` function (such as when using the `resources` convention), then calling `delete/2` from `PhoenixSwagger.Path` will now cause a compilation error. To avoid this problem, include the full module name:
+  ```elixir
+  swagger_path(:delete) do
+    PhoenixSwagger.Path.delete "/api/users/{id}"
+    summary "Delete User"
+  end
+  ```
+
 # 0.7.1
 
   * Use the :load_from_system_env Endpoint config flag to detect dynamic host and port configuration

--- a/examples/simple/lib/simple_web/controllers/user_controller.ex
+++ b/examples/simple/lib/simple_web/controllers/user_controller.ex
@@ -85,7 +85,6 @@ defmodule SimpleWeb.UserController do
   end
 
   swagger_path(:show) do
-    get "/api/users/{id}"
     summary "Show User"
     description "Show a user by ID"
     produces "application/json"
@@ -128,7 +127,7 @@ defmodule SimpleWeb.UserController do
   end
 
   swagger_path(:delete) do
-    delete "/api/users/{id}"
+    PhoenixSwagger.Path.delete "/api/users/{id}"
     summary "Delete User"
     description "Delete a user by ID"
     parameter :id, :path, :integer, "User ID", required: true, example: 3

--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -108,7 +108,7 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
     |> Enum.reduce(swagger_map, &merge_paths/2)
   end
 
-  defp find_swagger_path_function(route = %{opts: action, path: path}) when is_atom(action) do
+  defp find_swagger_path_function(route = %{opts: action, path: path, verb: verb}) when is_atom(action) do
     controller = find_controller(route)
     swagger_fun = "swagger_path_#{action}" |> String.to_atom()
 
@@ -117,7 +117,8 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
         %{
           controller: controller,
           swagger_fun: swagger_fun,
-          path: format_path(path)
+          path: format_path(path),
+          verb: verb
         }
       true ->
         Logger.warn "Warning: #{controller} module didn't load."
@@ -135,11 +136,11 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
   end
 
   defp controller_function_exported?(%{controller: controller, swagger_fun: fun}) do
-    function_exported?(controller, fun, 0)
+    function_exported?(controller, fun, 1)
   end
 
-  defp get_swagger_path(%{controller: controller, swagger_fun: fun}) do
-    apply(controller, fun, [])
+  defp get_swagger_path(route = %{controller: controller, swagger_fun: fun}) do
+    apply(controller, fun, [route])
   end
 
   defp merge_paths(path, swagger_map) do

--- a/lib/phoenix_swagger/path.ex
+++ b/lib/phoenix_swagger/path.ex
@@ -89,30 +89,29 @@ defmodule PhoenixSwagger.Path do
     conversion to a JSON map.
     See http://swagger.io/specification/#pathsObject
     """
-    defstruct path: "", verb: "", operation: %OperationObject{}
+    defstruct path: nil, verb: nil, operation: %OperationObject{}
   end
 
-  @doc "Initializes a Swagger Path DSL block with a get verb"
-  def get(path), do: %PathObject{path: path, verb: "get"}
+  @doc "Initializes a PathObject with verb \"get\" and given path"
+  def get(path_obj = %PathObject{}, path), do: %{path_obj | path: path, verb: "get"}
 
-  @doc "Initializes a Swagger Path DSL block with a post verb"
-  def post(path), do: %PathObject{path: path, verb: "post"}
+  @doc "Initializes a PathObject with verb \"post\" and given path"
+  def post(path_obj = %PathObject{}, path), do: %{path_obj | path: path, verb: "post"}
 
-  @doc "Initializes a Swagger Path DSL block with a put verb"
-  def put(path), do: %PathObject{path: path, verb: "put"}
+  @doc "Initializes a PathObject with verb \"put\" and given path"
+  def put(path_obj = %PathObject{}, path), do: %{path_obj | path: path, verb: "put"}
 
-  @doc "Initializes a Swagger Path DSL block with a patch verb"
-  def patch(path), do: %PathObject{path: path, verb: "patch"}
+  @doc "Initializes a PathObject with verb \"patch\" and given path"
+  def patch(path_obj = %PathObject{}, path), do: %{path_obj | path: path, verb: "patch"}
 
-  @doc "Initializes a Swagger Path DSL block with a delete verb"
-  def delete(path), do: %PathObject{path: path, verb: "delete"}
+  @doc "Initializes a PathObject with verb \"delete\" and given path"
+  def delete(path_obj = %PathObject{}, path), do: %{path_obj | path: path, verb: "delete"}
 
-  @doc "Initializes a Swagger Path DSL block with a head verb"
-  def head(path), do: %PathObject{path: path, verb: "head"}
+  @doc "Initializes a PathObject with verb \"head\" and given path"
+  def head(path_obj = %PathObject{}, path), do: %{path_obj | path: path, verb: "head"}
 
-  @doc "Initializes a Swagger Path DSL block with a options verb"
-  def options(path), do: %PathObject{path: path, verb: "options"}
-
+  @doc "Initializes a PathObject with verb \"options\" and given path"
+  def options(path_obj = %PathObject{}, path), do: %{path_obj | path: path, verb: "options"}
 
   @doc """
   Adds the summary section to the operation of a swagger `%PathObject{}`

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -46,7 +46,12 @@ defmodule PhoenixSwagger.PathTest do
     consumes "application/json"
     produces "application/json"
     parameter :name, :query, :string, "User name change", required: true
-    response 200, "OK", :string
+    response 200, "OK", %Schema{type: :string}
+  end
+
+  swagger_path :health_check do
+    summary "verb and path will be taken from router"
+    response 200, "OK", %Schema{type: :string}
   end
 
   def user_schema do
@@ -68,7 +73,8 @@ defmodule PhoenixSwagger.PathTest do
   end
 
   test "swagger_path_show produces expected swagger json" do
-    assert swagger_path_show() == %{
+    route = %{verb: :get, path: "/api/v1/users/{id}"}
+    assert swagger_path_show(route) == %{
       "/api/v1/users/{id}" => %{
         "get" => %{
           "description" => "Get a user by ID",
@@ -99,7 +105,8 @@ defmodule PhoenixSwagger.PathTest do
   end
 
   test "swagger_path_index produces expected swagger json" do
-    assert swagger_path_index() == %{
+    route = %{verb: :get, path: "/api/v1/users/"}
+    assert swagger_path_index(route) == %{
       "/api/v1/users" => %{
         "get" => %{
           "produces" => ["application/json"],
@@ -169,7 +176,8 @@ defmodule PhoenixSwagger.PathTest do
   end
 
   test "swagger_path_create produces expected swagger json" do
-    assert swagger_path_create() == %{
+    route = %{verb: :post, path: "/api/v1/users/"}
+    assert swagger_path_create(route) == %{
       "/api/v1/{team}/users" => %{
         "post" => %{
           "consumes" => ["application/json"],
@@ -240,7 +248,8 @@ defmodule PhoenixSwagger.PathTest do
   end
 
   test "swagger_path_update produces expected swagger json" do
-    assert swagger_path_update() == %{"/api/v1/user/{id}" =>
+    route = %{verb: :patch, path: "/api/v1/users/{id}"}
+    assert swagger_path_update(route) == %{"/api/v1/user/{id}" =>
       %{"patch" =>
         %{"consumes" => ["application/json"],
           "description" => "",
@@ -249,7 +258,29 @@ defmodule PhoenixSwagger.PathTest do
                              "name" => "name", "required" => true, "type" => "string"}],
           "produces" => ["application/json"],
           "responses" => %{"200" => %{"description" => "OK",
-          "schema" => %{"$ref" => "#/definitions/string"}}},
+          "schema" => %{"type" => "string"}}},
       "summary" => "Update a users name", "tags" => ["PathTest"]}}}
   end
+
+  test "verb and path can be inferred" do
+    route = %{verb: :get, path: "/health"}
+    assert swagger_path_health_check(route) == %{
+      "/health" => %{
+        "get" => %{
+          "description" => "",
+          "operationId" => "PhoenixSwagger.PathTest.health_check",
+          "parameters" => [],
+          "responses" => %{
+            "200" => %{
+              "description" => "OK",
+              "schema" => %{"type" => "string"}
+            }
+          },
+          "summary" => "verb and path will be taken from router",
+          "tags" => ["PathTest"]
+        }
+      }
+    }
+  end
+
 end


### PR DESCRIPTION
Closes #145 

This PR allows the HTTP verb and path to be inferred from the phoenix router.
Earlier versions of phoenix_swagger allowed this, but it was changed to allow overriding it from the controller.

The new version passes the verb and path from the mix task in to the `swagger_path_***` function for use as default values.

/cc @pablobcb