### PR TITLE
add nullable as a property

### DIFF
--- a/lib/phoenix_swagger/schema.ex
+++ b/lib/phoenix_swagger/schema.ex
@@ -37,7 +37,7 @@ defmodule PhoenixSwagger.Schema do
     :additionalProperties,
     :discriminator,
     :example,
-    :nullable
+    :'x-nullable'
   ]
 
   @doc """
@@ -179,7 +179,9 @@ defmodule PhoenixSwagger.Schema do
   end
   def property(model = %Schema{type: :object}, name, type = %Schema{}, description, opts) do
     {required?, opts} = Keyword.pop(opts, :required)
+    {nullable?, opts} = Keyword.pop(opts, :nullable)
     property_schema = struct!(type, [description: type.description || description] ++ opts)
+    property_schema = if nullable?, do: %{property_schema | :'x-nullable' => true}, else: property_schema
     properties = (model.properties || %{}) |> Map.put(name, property_schema)
     model = %{model | properties: properties}
     if required?, do: required(model, name), else: model

--- a/lib/phoenix_swagger/schema.ex
+++ b/lib/phoenix_swagger/schema.ex
@@ -36,7 +36,9 @@ defmodule PhoenixSwagger.Schema do
     :properties,
     :additionalProperties,
     :discriminator,
-    :example]
+    :example,
+    :nullable
+  ]
 
   @doc """
   Construct a new %Schema{} struct using the schema DSL.
@@ -215,7 +217,7 @@ defmodule PhoenixSwagger.Schema do
       [do: {:__block__, _, exprs}] -> exprs
       [do: expr] -> [expr]
     end
-    
+
     body =
       exprs
       |> Enum.map(fn {name, line, args} -> {:property, line, [name | args]} end)

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -66,6 +66,7 @@ defmodule PhoenixSwagger.PathTest do
           properties do
             subscribe_to_mailing_list :boolean, "mailing list subscription", default: true
             send_special_offers :boolean, "special offers list subscription", default: true
+            phone_number :string, "specified phone", nullable: true
           end
         end)
       end
@@ -231,7 +232,12 @@ defmodule PhoenixSwagger.PathTest do
                         "default" => true,
                         "description" => "mailing list subscription",
                         "type" => "boolean"
-                      }
+                      },
+                      "phone_number" => %{
+                        "description" => "specified phone",
+                        "type" => "string",
+                        "nullable" => true
+                      },
                     },
                     "type" => "object"
                   }

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -236,7 +236,7 @@ defmodule PhoenixSwagger.PathTest do
                       "phone_number" => %{
                         "description" => "specified phone",
                         "type" => "string",
-                        "nullable" => true
+                        "x-nullable" => true
                       },
                     },
                     "type" => "object"


### PR DESCRIPTION
From https://swagger.io/specification/#schemaObject under "Fixed fields":

> Allows sending a null value for the defined schema. Default value is false.