### PR TITLE
Returns multiple validation errors

### DIFF
--- a/lib/phoenix_swagger/conn_validator.ex
+++ b/lib/phoenix_swagger/conn_validator.ex
@@ -89,7 +89,7 @@ defmodule PhoenixSwagger.ConnValidator do
   defp validate_body_params(path, conn) do
     case Validator.validate(path, conn.body_params) do
       :ok -> :ok
-      {:error, [{error, error_path} | _], _path} -> {:error, error, error_path}
+      {:error, [{_error, _error_path} | _] = errors, path} -> {:error, errors, path}
       {:error, error, error_path} ->  {:error, error, error_path}
     end
   end

--- a/lib/phoenix_swagger/conn_validator.ex
+++ b/lib/phoenix_swagger/conn_validator.ex
@@ -87,11 +87,7 @@ defmodule PhoenixSwagger.ConnValidator do
   end
 
   defp validate_body_params(path, conn) do
-    case Validator.validate(path, conn.body_params) do
-      :ok -> :ok
-      {:error, [{_error, _error_path} | _] = errors, path} -> {:error, errors, path}
-      {:error, error, error_path} ->  {:error, error, error_path}
-    end
+    Validator.validate(path, conn.body_params)
   end
 
   defp equal_paths?([], []), do: true


### PR DESCRIPTION
As `PhoenixSwagger.ConnValidator` module doc described

```
* `{:error, [{message, path}], path}` if more than one validation error has been detected
```

Returns multiple errors if multiple validation error detected.