### PR TITLE
send 405 Method Not Allowed for other methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.1
+
+  * fix for crash on non-GET requests
+
 # 0.8.0
 
   * Passing module names and output path as mix task parameters is no longer supported.

--- a/lib/phoenix_swagger/plug/swaggerui.ex
+++ b/lib/phoenix_swagger/plug/swaggerui.ex
@@ -152,6 +152,10 @@ defmodule PhoenixSwagger.Plug.SwaggerUI do
     end
   end
 
+  match "/*paths" do
+    Conn.send_resp(conn, 405, "method not allowed")
+  end
+
   @doc """
   Plug.init callback
 


### PR DESCRIPTION
We recently saw a crash when someone tried to POST to our Swagger file, and nothing matched.

I could also be convinced that `404 Not Found` is the right thing to return in this case.