### PR TITLE
Removed empty objects and arrays from json

### DIFF
--- a/lib/phoenix_swagger.ex
+++ b/lib/phoenix_swagger.ex
@@ -237,6 +237,10 @@ defmodule PhoenixSwagger do
     |> Map.from_struct()
     |> to_json()
   end
+  def to_json(%{type: typ, '$ref': ref}) when is_nil(typ) and is_nil(ref), do: :null
+  def to_json(%{type: :object, properties: nil}), do: :null
+  def to_json(%{type: :object, properties: %{}=props}) when map_size(props) == 0, do: :null
+  def to_json(%{type: :array, items: %{type: typ, '$ref': ref}}) when is_nil(typ) and is_nil(ref), do: :null
   def to_json(value) when is_map(value) do
     value
     |> Enum.map(fn {k,v} -> {to_string(k), to_json(v)} end)

--- a/test/json_api_test.exs
+++ b/test/json_api_test.exs
@@ -81,15 +81,11 @@ defmodule PhoenixSwagger.JsonApiTest do
           },
           "type" => "object"
         },
-        "included" => %{
-          "description" => "Included resources",
-          "type" => "array",
-          "items" => %{}
-        }
       },
       "required" => ["data"],
       "type" => "object"
     }
+    assert !Map.has_key?(user_schema, "included")
   end
 
   test "produces expected user resource schema" do


### PR DESCRIPTION
When generating swift4 code using swagger-codegen, it fails due to invalid objects and arrays.
In case of object type, it is invalid when properties is empty, and for array, when items is empty.