### PR TITLE
Adds type and id to the `included` array of a single jsonapi object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * fix for crash on non-GET requests
   * Validate number type in query parameter
+  * Adds `id` and `type` properties to the `included`-items schema
 
 # 0.8.0
 

--- a/lib/phoenix_swagger/json_api.ex
+++ b/lib/phoenix_swagger/json_api.ex
@@ -120,7 +120,13 @@ defmodule PhoenixSwagger.JsonApi do
         included: %Schema {
           type: :array,
           description: "Included resources",
-          items: %Schema{}
+          items: %Schema {
+            type:  :object,
+            properties: %{
+              type: %Schema{type: :string, description: "The JSON-API resource type"},
+              id: %Schema{type: :string, description: "The JSON-API resource ID"},
+            }
+          }
         }
       },
       required:  [:data]

--- a/test/json_api_test.exs
+++ b/test/json_api_test.exs
@@ -84,7 +84,19 @@ defmodule PhoenixSwagger.JsonApiTest do
         "included" => %{
           "description" => "Included resources",
           "type" => "array",
-          "items" => %{}
+          "items" => %{
+            "properties" => %{
+              "id" => %{
+                "description" => "The JSON-API resource ID",
+                "type" => "string"
+              },
+              "type" => %{
+                "description" => "The JSON-API resource type",
+                "type" => "string"
+              }
+            },
+            "type" => "object"
+          }
         }
       },
       "required" => ["data"],


### PR DESCRIPTION
This PR adds the missing fields `type` and `id` to the included array of a single JSON-Api Response, acording to your comment in the PR #182 . This should also fix the issue with `swagger-codegen` and invalid/unkown objects in a array.

https://github.com/xerions/phoenix_swagger/pull/182#pullrequestreview-121329948
