### PR TITLE
update documentation and example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,13 +26,13 @@ to the application list in your `mix.exs`.
 
 `ex_json_schema` is an optional dependency of `phoenix_swagger` required only for schema validation plug and test helper.
 
-Add `:phoenix_swagger` to the list of compilers to automatically update the swagger files each time the app is compiled:
+Append `:phoenix_swagger` to the list of compilers to automatically update the swagger files each time the app is compiled:
 
 ```elixir
 def project do
 [
   ...
-  compilers: [:phoenix, :gettext, :phoenix_swagger] ++ Mix.compilers,
+  compilers: [:phoenix, :gettext] ++ Mix.compilers ++ [:phoenix_swagger],
   ...
 end
 ```

--- a/examples/simple/mix.exs
+++ b/examples/simple/mix.exs
@@ -6,7 +6,7 @@ defmodule Simple.Mixfile do
      version: "0.0.1",
      elixir: "~> 1.2",
      elixirc_paths: elixirc_paths(Mix.env),
-     compilers: [:phoenix, :gettext, :phoenix_swagger] ++ Mix.compilers,
+     compilers: [:phoenix, :gettext] ++ Mix.compilers ++ [:phoenix_swagger],
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      aliases: aliases(),


### PR DESCRIPTION
`:phoenix_swagger` compiler must be append at the end of `:compilers` list to avoid compilation issues.

* update documentation

* update sample `mix.exs`