### PR TITLE
Add support for multiple examples in schema

### DIFF
--- a/examples/simple/lib/simple_web/controllers/user_controller.ex
+++ b/examples/simple/lib/simple_web/controllers/user_controller.ex
@@ -113,9 +113,16 @@ defmodule SimpleWeb.UserController do
         user: %{name: "Joe", email: "joe4@mail.com"}
       }
     end
-    response 200, "Updated Successfully", Schema.ref(:UserResponse), example: %{
-      data: %{
-        id: 3, name: "Joe", email: "Joe5@mail.com", inserted_at: "2017-02-08T12:34:55Z", updated_at: "2017-02-12T13:45:23Z"
+    response 200, "Updated Successfully", Schema.ref(:UserResponse), examples: %{
+      Joe: %{
+        data: %{
+          id: 3, name: "Joe", email: "Joe5@mail.com", inserted_at: "2017-02-08T12:34:55Z", updated_at: "2017-02-12T13:45:23Z"
+        }
+      },
+      Diane: %{
+        data: %{
+          id: 4, name: "Diane", email: "Joe5@mail.com", inserted_at: "2018-10-04T12:34:55Z", updated_at: "2018-10-04T12:34:55Z"
+        }
       }
     }
   end

--- a/examples/simple/priv/static/swagger.json
+++ b/examples/simple/priv/static/swagger.json
@@ -13,12 +13,21 @@
               "$ref": "#/definitions/UserResponse"
             },
             "examples": {
-              "application/json": {
+              "Joe": {
                 "data": {
                   "updated_at": "2017-02-12T13:45:23Z",
                   "name": "Joe",
                   "inserted_at": "2017-02-08T12:34:55Z",
                   "id": 3,
+                  "email": "Joe5@mail.com"
+                }
+              },
+              "Diane": {
+                "data": {
+                  "updated_at": "2018-10-04T12:34:55Z",
+                  "name": "Diane",
+                  "inserted_at": "2018-10-04T12:34:55Z",
+                  "id": 4,
                   "email": "Joe5@mail.com"
                 }
               }

--- a/lib/phoenix_swagger/schema.ex
+++ b/lib/phoenix_swagger/schema.ex
@@ -37,6 +37,7 @@ defmodule PhoenixSwagger.Schema do
     :additionalProperties,
     :discriminator,
     :example,
+    :examples,
     :'x-nullable'
   ]
 
@@ -675,6 +676,35 @@ defmodule PhoenixSwagger.Schema do
   """
   def example(model = %Schema{}, example) do
     %{model | example: example}
+  end
+
+  @doc """
+  Adds multiple examples of the schema.
+
+    ## Example
+
+    iex> alias PhoenixSwagger.Schema
+    ...> %Schema{type: :object, properties: %{phone_number: %Schema{type: :string}}}
+    ...> |> Schema.examples(%{example_1: %{phone_number: "555-123-456"},example_2: %{phone_number: "555-246-0549"}})
+    %PhoenixSwagger.Schema{
+      type: :object,
+      properties: %{
+        phone_number: %PhoenixSwagger.Schema{
+          type: :string
+        }
+      },
+      examples: %{
+        example_1: %{
+          phone_number: "555-123-456"
+        },
+        example_2: %{
+          phone_number: "555-246-0549"
+        }
+      }
+    }
+  """
+  def examples(model = %Schema{}, examples) when is_map(examples) do
+    %{model | examples: examples}
   end
 
   @doc """


### PR DESCRIPTION
Add support for [multiple examples in schemas](https://swagger.io/docs/specification/adding-examples/).