### PR TITLE
Query array/enum parrameters  validation

### DIFF
--- a/test/test_spec/swagger_test_spec_2.json
+++ b/test/test_spec/swagger_test_spec_2.json
@@ -50,12 +50,43 @@
                         "collectionFormat": "csv"
                     },
                     {
+                        "name": "class",
+                        "in": "query",
+                        "description": "animal class to filter by",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "mammals",
+                                "birds",
+                                "fish",
+                                "reptiles",
+                                "amphibians",
+                                "arthropods"
+                            ]
+                        },
+                        "collectionFormat": "csv"
+                    },
+                    {
                         "name": "limit",
                         "in": "query",
                         "description": "maximum number of results to return",
                         "required": false,
                         "type": "integer",
                         "format": "int32"
+                    },
+                    {
+                        "name": "size",
+                        "in": "query",
+                        "description": "Pets size to filter by",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "small",
+                            "medium",
+                            "big"
+                        ]
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
Added simple validation for:
- query enum params
- query array params including enum as well (comma separated) 

Note: previously using such query params would lead to Internal Server Error 
"(FunctionClauseError) no function clause matching in ConnValidator.validate_query_params/1", 
though swagger schema was valid and successfully generated 

