### PR TITLE
Update Travis CI matrix and set Elixir 1.6 as min. in PhoenixSwagger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,11 @@ dist: trusty
 language: elixir
 
 elixir:
-    - 1.3.4
-    - 1.4.1
-    - 1.5.1
     - 1.6.1
     - 1.7.4
 
 otp_release:
-    - 18.3
     - 19.0
     - 20.0
-
-matrix:
-  exclude:
-    - elixir: 1.3.4
-      otp_release: 20.0
-    - elixir: 1.4.1
-      otp_release: 20.0
-    - elixir: 1.6.1
-      otp_release: 18.3
-    - elixir: 1.7.4
-      otp_release: 18.3
 
 script: "mix test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ elixir:
     - 1.4.1
     - 1.5.1
     - 1.6.1
+    - 1.7.4
 
 otp_release:
     - 18.3
@@ -19,6 +20,8 @@ matrix:
     - elixir: 1.4.1
       otp_release: 20.0
     - elixir: 1.6.1
+      otp_release: 18.3
+    - elixir: 1.7.4
       otp_release: 18.3
 
 script: "mix test"

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixSwagger.Mixfile do
   use Mix.Project
 
-  @version "0.8.1"
+  @version "0.8.2"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule PhoenixSwagger.Mixfile do
     [
       app: :phoenix_swagger,
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.6",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
__Changes__
* Add `Elixir-1.7.4` to Travis CI test matrix

__Why?__
We should ensure correct flow in latest Elixir version.

cc. @mbuhot 
