### PR TITLE
Derive schemes from endpoint :url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /deps
 erl_crash.dump
 *.ez
+.idea/
+*.iml

--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -180,12 +180,20 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
     url = Keyword.get(endpoint_config, :url)
     host = Keyword.get(url, :host, "localhost")
     port = Keyword.get(url, :port, 4000)
+    scheme = Keyword.get(url, :scheme, :http)
 
     swagger_map =
       if (!load_from_system_env) and is_binary(host) and (is_integer(port) or is_binary(port)) do
         Map.put_new(swagger_map, :host, "#{host}:#{port}")
       else
         swagger_map # host / port may be {:system, "ENV_VAR"} tuples or loaded in Endpoint.init callback
+      end
+
+    swagger_map =
+      if scheme == :https do
+        Map.put_new(swagger_map, :schemes, ["https", "http"])
+      else
+        swagger_map
       end
 
     case endpoint_config[:https] do


### PR DESCRIPTION
## Summary

When handling url schemes (http/https), phoenix swagger currently does only take into account if there is set up a `:https` server in the endpoint config. Instead, it should first lookup if under the endpoint `:url` config a custom scheme is defined.

## Problem

Currently, phoenix swagger is generating the base url with scheme “https” only if in the phoenix `endpoint_config` it is set as distinct `:https` server. (see https://github.com/xerions/phoenix_swagger/blob/master/lib/mix/tasks/swagger.generate.ex#L178) The `collect_host_from_endpoint`. It does not consider the endpoint `:url` config, in particular it ignores `:scheme` (see below).

On the other side, it is a common scenario to run one's application behind a (https) reverse proxy. It is therefore in the general interest, to allow generating https base paths for the client communication – although the phoenix server is running only in https.

The phoenix docs are clear on the issue. It says that `:url` is for “generating URLs throughout the app”. https://hexdocs.pm/phoenix/Phoenix.Endpoint.html Moreover, the docs explicitly mention the reverse proxy issue:

```The :scheme option accepts "http" and "https" values. Default value is infered from top level :http or :https option. It is useful when hosting Phoenix behind a load balancer or reverse proxy and terminating SSL there.```

This PR alters the behavior of phoenix swagger to that extent, that first the configuration in `:url` is taken into account.