### PR TITLE
Fix bug where templated routes are sometimes matched before specific routes

### DIFF
--- a/lib/phoenix_swagger/conn_validator.ex
+++ b/lib/phoenix_swagger/conn_validator.ex
@@ -18,7 +18,10 @@ defmodule PhoenixSwagger.ConnValidator do
   end
 
   defp find_matching_path(conn) do
-    found = Enum.find(:ets.tab2list(@table), fn({path, base_path, _}) ->
+    found =
+      :ets.tab2list(@table)
+      |> Enum.sort()
+      |> Enum.find(fn({path, base_path, _}) ->
       base_path_segments = String.split(base_path || "", "/") |> tl
       path_segments = String.split(path, "/") |> tl
       path_info_without_base = remove_base_path(conn.path_info, base_path_segments)

--- a/test/test_spec/swagger_test_spec_3.json
+++ b/test/test_spec/swagger_test_spec_3.json
@@ -1,0 +1,18 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/pets/cats": {
+      "get": {
+        "summary": "",
+        "responses": {},
+        "parameters": [],
+        "description": ""
+      }
+    }
+  },
+  "info": {
+    "version": "1.0",
+    "title": "Simple App"
+  },
+  "definitions": {}
+}

--- a/test/validate_plug_test.exs
+++ b/test/validate_plug_test.exs
@@ -10,7 +10,7 @@ defmodule ValidatePlugTest do
   @table :validator_table
 
   setup do
-    schema = Validator.parse_swagger_schema(["test/test_spec/swagger_test_spec.json", "test/test_spec/swagger_test_spec_2.json"])
+    schema = Validator.parse_swagger_schema(["test/test_spec/swagger_test_spec.json", "test/test_spec/swagger_test_spec_2.json", "test/test_spec/swagger_test_spec_3.json"])
     on_exit fn ->
       :ets.delete_all_objects(@table)
     end
@@ -82,6 +82,14 @@ defmodule ValidatePlugTest do
     test_conn = Validate.call(test_conn, [])
     assert {400, _, "{\"error\":{\"path\":\"#/size\",\"message\":\"Value \\\"extra-big\\\" is not allowed in enum.\"}}"}
            = sent_resp(test_conn)
+  end
+
+  test "validation matches specific route before templated route" do
+    test_conn = init_conn(:get, "/api/pets/cats", %{}, %{})
+    test_conn = Validate.call(test_conn, [])
+    assert is_nil test_conn.status
+    assert is_nil test_conn.resp_body
+    assert test_conn.private[:phoenix_swagger][:valid]
   end
 
   defp init_conn(verb, path, body_params \\ %{}, path_params \\ %{}) do


### PR DESCRIPTION
Ensure that a route like `/pets/cats` is matched before `/pets/{id}`. Currently, this overlapping route behaviour is not always handled correctly (depends on the default sort order).