### PR TITLE
add possibility to return json 404 error from swagerUI plug

### DIFF
--- a/lib/phoenix_swagger/plug/swaggerui.ex
+++ b/lib/phoenix_swagger/plug/swaggerui.ex
@@ -160,10 +160,17 @@ defmodule PhoenixSwagger.Plug.SwaggerUI do
   # Render the swagger.json file or 404 for any other file
   get "/*paths" do
     spec_url = conn.assigns.spec_url
-
     case conn.path_params["paths"] do
       [^spec_url] -> Conn.send_file(conn, 200, conn.assigns.swagger_file_path)
-      _ -> Conn.send_resp(conn, 404, "not found")
+      _ ->
+        if accept_json?(conn) do
+          conn
+          |> Conn.put_resp_content_type("application/json")
+          Conn.send_resp(conn, 404, Poison.encode!(%{"Error": "not found"}))
+          |> halt
+        else
+          Conn.send_resp(conn, 404, "not found")
+        end
     end
   end
 
@@ -197,5 +204,12 @@ defmodule PhoenixSwagger.Plug.SwaggerUI do
     |> Conn.assign(:spec_url, url)
     |> Conn.assign(:swagger_file_path, Path.join([Application.app_dir(app), swagger_file_path]))
     |> super([])
+  end
+
+  defp accept_json?(conn) do
+    case get_req_header(conn, "accept") do
+      ["application/json"] -> true
+      _ -> false
+    end
   end
 end


### PR DESCRIPTION
swagerUI plug may handle requests for non exists spec files. In this
case it returns 404 and `not found` text. This commits adds ability
to send 404 json response if Accept header is set to `application/json`
to make happy applications that wait for a json response.