### PR TITLE
Warn when no phoenix_swagger config found

### DIFF
--- a/lib/mix/tasks/swagger.generate.ex
+++ b/lib/mix/tasks/swagger.generate.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
   @default_title "<enter your title>"
   @default_version "0.0.1"
 
-  defp app_name, do: Mix.Project.get!().project()[:app]
+  defp app_name(), do: Mix.Project.get!().project()[:app]
 
   def run(_args) do
     Mix.Task.run("compile")
@@ -36,6 +36,17 @@ defmodule Mix.Tasks.Phx.Swagger.Generate do
       app_name()
       |> Application.get_env(:phoenix_swagger, [])
       |> Keyword.get(:swagger_files, %{})
+
+    if (Enum.empty?(swagger_files) && !Mix.Task.recursing?()) do
+      Logger.warn("""
+        No swagger configuration found. Ensure phoenix_swagger is configured, eg:
+
+        config #{inspect(app_name())}, :phoenix_swagger,
+          swagger_files: %{
+            ...
+          }
+        """)
+    end
 
     Enum.each(swagger_files, fn {output_file, config} ->
       result =


### PR DESCRIPTION
It can be hard to debug when phoenix_swagger is misconfigured and it fails silently.

This change outputs a warning like:

```
20:15:31.855 [warn]  No swagger configuration found. Ensure phoenix_swagger is configured, eg:

config :promo, :phoenix_swagger,
  swagger_files: %{
    ...
  }
```

The warning does not apply when recursing in umbrella applications,
only when running the compiler / mix task directly on a mix project.