### PR TITLE
Update ex_json_schema to 0.6

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule PhoenixSwagger.Mixfile do
     [
       {:poison, "~> 2.2 or ~> 3.0", optional: true},
       {:jason, "~> 1.0", optional: true},
-      {:ex_json_schema, "~> 0.5", optional: true},
+      {:ex_json_schema, "~> 0.6", optional: true},
       {:plug, "~> 1.4"},
       {:ex_doc, "~> 0.18", only: :dev, runtime: false},
       {:dialyxir, "~> 0.5", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "ex_json_schema": {:hex, :ex_json_schema, "0.5.6", "9a96edd51a00fc005e12a773a7a79e507a77855e69fcb3d9a02f7f39c3265c03", [:mix], [], "hexpm"},
+  "ex_json_schema": {:hex, :ex_json_schema, "0.6.1", "b57c0588385b8262b80f19d33d9b9b71fcd60d247691abf2635b57a03ec0ad44", [:mix], [], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/validator_test.exs
+++ b/test/validator_test.exs
@@ -61,17 +61,15 @@ defmodule ValidatorTest do
     assert {:error, :resource_not_exists} = Validator.validate("/get/pets/id", %{"id" => "1"})
     assert :ok = Validator.validate("/get/pets/{id}", %{"id" => 1})
     assert {:error, :resource_not_exists} = Validator.validate("/pets", %{"id" => 1})
-    assert {:error,
-            [{"Required property id was not present.", "#"},
-             {"Required property pet was not present.", "#"}], "/post/pets"} = Validator.validate("/post/pets", %{})
+    assert {:error, "Required properties id, pet were not present.", "#"} =
+      Validator.validate("/post/pets", %{})
     assert {:error,
             [{"Type mismatch. Expected Integer but got String.", "#/id"},
              {"Required property pet was not present.", "#"}], "/post/pets"} = Validator.validate("/post/pets", %{"id" => "wrong_id"})
     assert {:error, "Required property pet was not present.", "#"} = Validator.validate("/post/pets", %{"id" => 1})
-    assert {:error,
-            [{"Required property name was not present.", "#/pet"},
-             {"Required property tag was not present.", "#/pet"}], "/post/pets"}
-      = Validator.validate("/post/pets", %{"id" => 1, "pet" => %{}})
+
+    assert {:error, "Required properties name, tag were not present.", "#/pet"} =
+      Validator.validate("/post/pets", %{"id" => 1, "pet" => %{}})
     assert {:error, "Required property tag was not present.", "#/pet"}
       = Validator.validate("/post/pets", %{"id" => 1, "pet" => %{"name" => "pet_name"}})
     assert :ok = Validator.validate("/post/pets", %{"id" => 1, "pet" => %{"name" => "pet_name", "tag" => "pet_tag"}})


### PR DESCRIPTION
There are some breaking changes in the newer version of ExJsonSchema.

Particularly the `ExJsonSchema.Validator.validate/4` function no longer exists, but has been replaced with `ExJsonSchema.Validator.validate_fragment/3` which performs a similar function.

