### PR TITLE
added support for having property name with "-" in the name e.g

### DIFF
--- a/lib/phoenix_swagger/schema.ex
+++ b/lib/phoenix_swagger/schema.ex
@@ -234,7 +234,14 @@ defmodule PhoenixSwagger.Schema do
 
     body =
       exprs
-      |> Enum.map(fn {name, line, args} -> {:property, line, [name | args]} end)
+      |> Enum.map(fn
+        {:"-", line, [{first, _, _}, {second, _, args}]= _bad_args} ->
+          name = :"#{first}-#{second}"
+          {:property, line, [name| args]}
+
+        {name, line, args} ->
+          {:property, line, [name | args]}
+      end)
       |> Enum.reduce(model, fn expr, acc ->
         quote do
           unquote(acc) |> unquote(expr)


### PR DESCRIPTION
now its possible to do:
    tunnel-ip(Schema.ref(:IpAddressWithPrefix), "local tunnel ip, BGP local IP", required: true)

following AST is generate for above property

  {:-, [line: 156],
   [
     {:tunnel, [line: 156], nil},
     {:ip, [line: 156],
      [
        {{:., [line: 156],
          [
            {:__aliases__, [counter: {******r, 53}, line: 156],
             [:Schema]},
            :ref
          ]}, [line: 156], [:IpAddressWithPrefix]},
        "local tunnel ip, BGP local IP",
        [required: true]
      ]}
   ]}