### PR TITLE
[MINOR] Support SwaggerUI config object injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /deps
 erl_crash.dump
 *.ez
+*.swp
+.tool-versions


### PR DESCRIPTION
## Feature
This allows a dev to specify a swagger configuration object that is used by the SwaggerUI JS object during construction. This allows you to have granular control of swagger and control the configuration per environment without having to rely on an external url or yaml file.

As an example I needed to set `oauth2RedirectUrl` depending on the env to integrate our oauth server.

## Changes
The SwaggerUI plug has been updated with the new (optional) `config_object` option. It expects a `map` with any key/val that is supported by swagger. https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/

Also the template was modified to place the config object in a variable - then we iterate on the config_object template var to set all the given options.

## Additional Notes
I didn't see any tests for this plug so I didn't take the time to add any. I can if need be though. I cobbled this together quickly for a fast moving project but now that it's operational I can take a step back and add proper test coverage.