### PR TITLE
allow nullable refs

### DIFF
--- a/lib/phoenix_swagger/test/schema_test.ex
+++ b/lib/phoenix_swagger/test/schema_test.ex
@@ -68,6 +68,15 @@ defmodule PhoenixSwagger.SchemaTest do
     swagger_nullable_to_json_schema(schema)
   end
 
+  defp swagger_nullable_to_json_schema(schema = %{"$ref" => ref, "x-nullable" => true})
+       when is_binary(ref) do
+    schema = schema
+      |> Map.drop(["$ref", "x-nullable"])
+      |> Map.put("oneOf", [%{"type" => "null"}, %{"$ref" => ref}])
+
+    swagger_nullable_to_json_schema(schema)
+  end
+
   defp swagger_nullable_to_json_schema(schema) when is_map(schema) do
     for {k, v} <- schema,
         into: %{},

--- a/lib/phoenix_swagger/validator.ex
+++ b/lib/phoenix_swagger/validator.ex
@@ -187,6 +187,15 @@ defmodule PhoenixSwagger.Validator do
     swagger_nullable_to_json_schema(schema)
   end
 
+  defp swagger_nullable_to_json_schema(schema = %{"$ref" => ref, "x-nullable" => true})
+       when is_binary(ref) do
+    schema = schema
+      |> Map.drop(["$ref", "x-nullable"])
+      |> Map.put("oneOf", [%{"type" => "null"}, %{"$ref" => ref}])
+
+    swagger_nullable_to_json_schema(schema)
+  end
+
   defp swagger_nullable_to_json_schema(schema) when is_map(schema) do
     for {k, v} <- schema,
         into: %{},

--- a/test/test_spec/swagger_test_spec_2.json
+++ b/test/test_spec/swagger_test_spec_2.json
@@ -249,9 +249,27 @@
                 "tag": {
                     "type": "string"
                 },
+                "full_name": {
+                    "$ref": "#/definitions/FullName",
+                    "x-nullable": true
+                },
                 "nickname" : {
                   "type": "string",
                   "x-nullable": true
+                }
+            }
+        },
+        "FullName": {
+            "type": "object",
+            "required": [
+                "first_name", "last_name"
+            ],
+            "properties": {
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
                 }
             }
         },

--- a/test/validator_test.exs
+++ b/test/validator_test.exs
@@ -112,6 +112,12 @@ defmodule ValidatorTest do
       Validator.validate("/post/pets", %{"id" => 1, "pet" => %{"name" => "pet_name", "tag" => "pet_tag", "nickname" => nil}})
 
     assert :ok =
+      Validator.validate("/post/pets", %{"id" => 1, "pet" => %{"name" => "pet_name", "tag" => "pet_tag", "full_name" => nil}})
+
+    assert :ok =
+      Validator.validate("/post/pets", %{"id" => 1, "pet" => %{"name" => "pet_name", "tag" => "pet_tag", "full_name" => %{"first_name" => "Boaty", "last_name" => "McBoatface"}}})
+
+    assert :ok =
              Validator.validate("/post/pets", %{
                "id" => 1,
                "pet" => %{"name" => "pet_name", "tag" => "pet_tag"}


### PR DESCRIPTION
@0xAX

This is like https://github.com/xerions/phoenix_swagger/pull/267, but works for `$ref`

I used the answer here to guide my solution:
https://stackoverflow.com/questions/23729973/how-to-specify-a-property-as-null-or-a-reference

I'm not sure if the x-nullable extension should allow this, but it's not part of the swagger spec so hard to have a definitive answer.