### PR TITLE
Fix boolean validation

### DIFF
--- a/lib/phoenix_swagger/conn_validator.ex
+++ b/lib/phoenix_swagger/conn_validator.ex
@@ -55,12 +55,12 @@ defmodule PhoenixSwagger.ConnValidator do
     end
   end
 
-  defp validate_boolean(_name, value, parameters) when value in ["true", "false"] do
+  defp validate_boolean(_name, value, parameters) when value in [true, false, "true", "false"] do
     validate_query_params(parameters)
   end
 
   defp validate_boolean(name, _value, _parameters) do
-    {:error, "Type mismatch. Expected Boolean but got String.", "#/#{name}"}
+    {:error, "Type mismatch. Expected Boolean but got something else.", "#/#{name}"}
   end
 
   defp validate_integer(name, value, parameters) do


### PR DESCRIPTION
# Problem

Presently only boolean values passed as query parameters pass validation. Example: `curl -X PATCH "/api/v1/profile?i_am_a_boolean=true`

But if same parameter is passed as JSON `{ "i_am_a_boolean": true }` validation fails with error: `Type mismatch. Expected Boolean but got String.`

# Fix

Add missing boolean literals to allowed boolean values
