### PR TITLE
Correct link to swagger JSON file in swagger-ui

### DIFF
--- a/priv/static/swagger-initializer.js
+++ b/priv/static/swagger-initializer.js
@@ -3,7 +3,7 @@ window.onload = function() {
 
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
-    url: "https://petstore.swagger.io/v2/swagger.json",
+    url: "swagger.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
Update the `url` passed to swagger-ui, so that it will use the default `swagger.json` generated by `mix phx.swagger.generate`.

closes #292 