### PR TITLE
Add priv directory to the package definition

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule PhoenixSwagger.Mixfile do
         "GitHub" => @source_url,
         "Slack" => "https://elixir-lang.slack.com/messages/phoenix_swagger"
       },
-      files: ~w(lib mix.exs .formatter.exs README.md CHANGELOG.md LICENSE config)
+      files: ~w(lib mix.exs .formatter.exs README.md CHANGELOG.md LICENSE config priv)
     ]
   end
 


### PR DESCRIPTION
As without it the swagger bundle will be missed in the hex releases.