### PR TITLE
Allow minor version updates of dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule PhoenixSwagger.Mixfile do
 
   defp deps do
     [
-      {:poison, "~> 6.0", optional: true},Jason
+      {:poison, "~> 6.0", optional: true},
       {:jason, "~> 1.4", optional: true},
       {:ex_json_schema, "~> 0.9", optional: true},
       {:plug, "~> 1.14"},

--- a/mix.exs
+++ b/mix.exs
@@ -35,10 +35,10 @@ defmodule PhoenixSwagger.Mixfile do
 
   defp deps do
     [
-      {:poison, "~> 6.0.0", optional: true},
-      {:jason, "~> 1.4.4", optional: true},
-      {:ex_json_schema, "~> 0.9.1", optional: true},
-      {:plug, "~> 1.14.2"},
+      {:poison, "~> 6.0", optional: true},Jason
+      {:jason, "~> 1.4", optional: true},
+      {:ex_json_schema, "~> 0.9", optional: true},
+      {:plug, "~> 1.14"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false}
     ]


### PR DESCRIPTION
Allow minor version updates of dependencies within mix.exs.  This allows users of this library to update shared dependencies to a minor version more-recent than the one in a release of phoenix_swagger.

Already relevant because phoenix applications use plug, which is up to version 1.18 (vs 1.14.x as-released in phoenix_swagger 0.8.4).