### PR TITLE
Make SwaggerUI compatible with Plug 1.19+

### DIFF
--- a/lib/phoenix_swagger/plug/swaggerui.ex
+++ b/lib/phoenix_swagger/plug/swaggerui.ex
@@ -18,7 +18,12 @@ defmodule PhoenixSwagger.Plug.SwaggerUI do
   swagger-ui should be shown with your swagger spec loaded.
   """
 
-  use Plug.Router
+  # init_mode: :runtime avoids baking Plug.Static.init/1's result into the
+  # compiled pipeline. The shape of that result changed between Plug 1.18
+  # (2-tuple `only_rules`) and Plug 1.19 (3-tuple), so a stale compile-time
+  # value would crash Plug.Static.path_status/2 at runtime. Runtime init
+  # always matches the loaded Plug version.
+  use Plug.Router, init_mode: :runtime
   alias Plug.Conn
 
   # Serve static assets before routing


### PR DESCRIPTION
## Summary

- Setting `init_mode: :runtime` on `use Plug.Router` in `PhoenixSwagger.Plug.SwaggerUI` so Plug.Static initialises against the loaded Plug version on each request.

## Why

Plug 1.19 changed `Plug.Static`'s internal options shape: `only_rules` went from a 2-tuple to a 3-tuple to support a configurable `only_status` (raise vs forbid on missing files). When SwaggerUI is compiled against an older Plug, the stale 2-tuple gets baked into the pipeline. At runtime against Plug 1.19, that crashes inside `Plug.Static.path_status/2`:

```
(FunctionClauseError) no function clause matching in Plug.Static.path_status/2
  # 1: {[], []}
  # 2: ["contractbook_api_swagger.json"]
```

`init_mode: :runtime` re-runs each plug's `init/1` per request, so the result always matches the loaded Plug. The cost is negligible for the SwaggerUI plug (typically dev/staging only).

## Test plan

Verified against the Contractbook API repo's 4 SwaggerUI tests (`ContractbookApi.SwaggerTest`, `DrafterApi.SwaggerTest`, `DrafterSCIM.API.SwaggerTest`, `PartnerToolsApi.SwaggerTest`) with `plug 1.19.1`:

- [x] All 4 swagger tests fail before this fix
- [x] All 4 swagger tests pass with this fix
- [x] Still passes with `plug 1.18.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)